### PR TITLE
fix: base URI without tailing /

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -104,10 +104,7 @@ class GGClient:
         extra_headers: Dict[str, str] = None,
         **kwargs
     ) -> Response:
-        if version:
-            endpoint = urllib.parse.urljoin(version + "/", endpoint)
-
-        url = urllib.parse.urljoin(self.base_uri, endpoint)
+        url = self._url_from_endpoint(endpoint, version)
 
         headers = (
             {**self.session.headers, **extra_headers}
@@ -117,6 +114,12 @@ class GGClient:
         return self.session.request(
             method=method, url=url, timeout=self.timeout, headers=headers, **kwargs
         )
+
+    def _url_from_endpoint(self, endpoint: str, version: Optional[str]) -> str:
+        if version:
+            endpoint = urllib.parse.urljoin(version + "/", endpoint)
+
+        return urllib.parse.urljoin(self.base_uri + "/", endpoint)
 
     def get(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -226,6 +226,42 @@ def test_client_creation(
         assert client.session.headers["Authorization"] == "Token {0}".format(api_key)
 
 
+@pytest.mark.parametrize(
+    ("base_uries", "version", "endpoints_and_urls"),
+    [
+        (
+            ("https://api.gitguardian.com",),
+            "v1",
+            (
+                ("multiscan", "https://api.gitguardian.com/v1/multiscan"),
+                ("scan", "https://api.gitguardian.com/v1/scan"),
+            ),
+        ),
+        (
+            (
+                "https://gg-onprem-instance.company.com/exposed",
+                "https://gg-onprem-instance.company.com/exposed/",
+            ),
+            "v1",
+            (
+                (
+                    "multiscan",
+                    "https://gg-onprem-instance.company.com/exposed/v1/multiscan",
+                ),
+                ("scan", "https://gg-onprem-instance.company.com/exposed/v1/scan"),
+            ),
+        ),
+    ],
+)
+def test_client__url_from_endpoint(base_uries, version, endpoints_and_urls):
+    for curr_base_uri in base_uries:
+        client = GGClient(api_key="validapi_keyforsure", base_uri=curr_base_uri)
+        for endpoint, expected_url in endpoints_and_urls:
+            assert (
+                client._url_from_endpoint(endpoint, version) == expected_url
+            ), "Could not get the expected URL for base_uri=`{}`".format(base_uri)
+
+
 @my_vcr.use_cassette
 def test_health_check(client: GGClient):
     health = client.health_check()


### PR DESCRIPTION
Because of the way `urllib.parse.urljoin` works, if the base URI didn't have a tailing `/`, the path would be truncated.

E.g. `https://onprem.company.com/exposed` with the enpoint `scan` (and version `v1`) would call `https://onprem.company.com/v1/scan` and not `https://onprem.company.com/exposed/v1/scan`.