### PR TITLE
Some small fixes

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -27,7 +27,7 @@ jobs:
           pipenv run black .
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -324,7 +324,7 @@ class MultiScanResultSchema(BaseSchema):
     scan_results = fields.List(
         fields.Nested(ScanResultSchema),
         required=True,
-        validates=validate.Length(min=1),
+        validate=validate.Length(min=1),
     )
 
     @post_load

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,7 +45,27 @@ class TestModel:
             (
                 MultiScanResultSchema,
                 MultiScanResult,
-                {"scan_results": [], "type": "hello"},
+                {
+                    "scan_results": [
+                        {
+                            "policy_break_count": 1,
+                            "policies": ["pol"],
+                            "policy_breaks": [
+                                {
+                                    "type": "break",
+                                    "policy": "mypol",
+                                    "matches": [
+                                        {
+                                            "match": "hello",
+                                            "type": "hello",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                    "type": "hello",
+                },
             ),
             (
                 PolicyBreakSchema,


### PR DESCRIPTION
This PR makes two fixes:

First it fixes a marshmallow warning about using kwargs arguments to declare fields:

>../../.local/share/virtualenvs/py-gitguardian-n9b0MJaw/lib/python3.8/site-packages/marshmallow/fields.py:218
  /home/agateau/.local/share/virtualenvs/py-gitguardian-n9b0MJaw/lib/python3.8/site-packages/marshmallow/fields.py:218: RemovedInMarshmallow4Warning: Passing field metadata as keyword arguments is deprecated. Use the explicit `metadata=...` argument instead. Additional metadata: {'validates': <Length(min=1, max=None, equal=None, error=None)>}


Turns out it was a typo.

Second, it fixes the CI to really run tests on all OS. Hopefully this is less involved than for ggshield (https://github.com/GitGuardian/ggshield/pull/164).
