### PR TITLE
feat(api_token): retrieve information about the API token being used

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -11,6 +11,7 @@ from .config import (
     MULTI_DOCUMENT_LIMIT,
 )
 from .models import (
+    APITokenResponse,
     Detail,
     Document,
     HealthCheckResponse,
@@ -332,4 +333,25 @@ class GGClient:
 
         obj.status_code = resp.status_code
 
+        return obj
+
+    def api_token_information(
+        self, extra_headers: Optional[Dict[str, str]] = None
+    ) -> Union[Detail, APITokenResponse]:
+        """
+        api_token_information handles the /token endpoint of the API
+
+        :param extra_headers: additional headers to add to the request
+        :return: Detail or APIToken response and status code
+        """
+
+        resp = self.get(endpoint="token", extra_headers=extra_headers)
+
+        obj: Union[Detail, APITokenResponse]
+        if is_ok(resp):
+            obj = APITokenResponse.SCHEMA.load(resp.json())
+        else:
+            obj = load_detail(resp)
+
+        obj.status_code = resp.status_code
         return obj

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Any, ClassVar, Dict, List, Optional, cast
 
 from marshmallow import (
@@ -505,3 +505,51 @@ class HealthCheckResponse(Base):
                 self.secrets_engine_version or "",
             )
         )
+
+
+class APITokenResponseSchema(BaseSchema):
+    type = fields.String(allow_none=False)
+    account_id = fields.Int(allow_none=False)
+    name = fields.String(allow_none=False)
+    scope = fields.List(fields.String)
+    expire_at = fields.DateTime(allow_none=True)
+
+    @post_load
+    def make_api_token_response(
+        self, data: Dict[str, Any], **kwargs: Any
+    ) -> "APITokenResponse":
+        return APITokenResponse(**data)
+
+
+class APITokenResponse(Base):
+    """
+    APIToken describes a quota category in the GitGuardian API.
+
+    Example:
+    {"type": "personal_access_token",
+     "account_id": 17,
+     "name": "My Token",
+     "scope": ["scan"],
+     "expire_at": "2021-04-18T00:00:00Z"}
+    """
+
+    SCHEMA = APITokenResponseSchema()
+
+    def __init__(
+        self,
+        type: str,
+        account_id: int,
+        name: str,
+        scope: List[str],
+        expire_at: Optional[datetime] = None,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self.type = type
+        self.account_id = account_id
+        self.name = name
+        self.scope = scope
+        self.expire_at = expire_at
+
+    def __repr__(self) -> str:
+        return "name:{0}".format(self.name)

--- a/tests/cassettes/test_api_token_information.yaml
+++ b/tests/cassettes/test_api_token_information.yaml
@@ -1,0 +1,54 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.3.4 (Linux;py3.8.10)
+      method: GET
+      uri: https://api.gitguardian.com/v1/token
+    response:
+      body:
+        string: '{"type":"personal_access_token","account_id":17,"name":"My Token","scope":["scan"],"expire_at":"2022-04-18T00:00:00Z"}'
+      headers:
+        Access-Control-Expose-Headers:
+          - X-App-Version
+        Allow:
+          - GET, HEAD, OPTIONS
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '149'
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 23 Mar 2022 17:08:46 GMT
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Server:
+          - nginx
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        Vary:
+          - Cookie
+        X-App-Version:
+          - 1a3fecc5
+        X-Content-Type-Options:
+          - nosniff
+          - nosniff
+        X-Frame-Options:
+          - DENY
+          - SAMEORIGIN
+        X-Secrets-Engine-Version:
+          - 2.64.0
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -260,6 +260,16 @@ def test_client__url_from_endpoint(base_uries, version, endpoints_and_urls):
 
 
 @my_vcr.use_cassette
+def test_api_token_information(client: GGClient):
+    response = client.api_token_information()
+    assert response.status_code == 200
+    assert str(response) == "name:My Token"
+
+    assert type(response.to_dict()) == OrderedDict
+    assert type(response.to_json()) == str
+
+
+@my_vcr.use_cassette
 def test_health_check(client: GGClient):
     health = client.health_check()
     assert health.status_code == 200

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,8 @@ from typing import OrderedDict
 import pytest
 
 from pygitguardian.models import (
+    APITokenResponse,
+    APITokenResponseSchema,
     Document,
     DocumentSchema,
     HealthCheckResponseSchema,
@@ -35,6 +37,17 @@ class TestModel:
     @pytest.mark.parametrize(
         "schema_klass, expected_klass, instance_data",
         [
+            (
+                APITokenResponseSchema,
+                APITokenResponse,
+                {
+                    "type": "personal_access_token",
+                    "account_id": 17,
+                    "name": "My Token",
+                    "scope": ["scan"],
+                    "expire_at": None,
+                },
+            ),
             (DocumentSchema, OrderedDict, {"filename": "hello", "document": "hello"}),
             (
                 HealthCheckResponseSchema,


### PR DESCRIPTION
Add a method to `GGClient` to retrieve information about the API token being used.

This endpoint is not available on GG's API _yet_.