### PR TITLE
Add a CHANGELOG

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,27 @@
+# This workflow only accepts PRs if they either contain a changelog fragment,
+# or have been applied the `skip-changelog` label.
+name: Changelog check
+
+on:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - 'opened'
+      - 'reopened'
+      - 'synchronize'
+      # For `skip-changelog` only.
+      - 'labeled'
+      - 'unlabeled'
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Check for changelog fragment'
+        uses: brettcannon/check-for-changed-files@v1.1.0
+        with:
+          file-pattern: |
+            changelog.d/*.md
+            CHANGELOG.md
+          skip-label: 'skip-changelog'
+          failure-message: 'Missing a changelog fragment in ${file-pattern}. Please add one using `scriv create` or apply the `${skip-label}` label to the pull request'

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -41,20 +41,26 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipenv==2022.10.4
           pipenv install --system --dev --skip-lock
+
       - name: Test with pytest
         run: |
           pipenv run coverage run --source pygitguardian -m pytest --disable-pytest-warnings
           pipenv run coverage report --fail-under=80
           pipenv run coverage xml
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+
       - uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
@@ -70,21 +76,31 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+
       - name: Install dependencies
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Build distribution
         run: >-
           python setup.py sdist bdist_wheel
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
-      - name: Release Notary Action
-        uses: docker://aevea/release-notary:0.9.1
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tags.outputs.tag }}
+          release_name: ${{ steps.tags.outputs.tag }}
+          draft: true
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+<a id='changelog-1.5.0'></a>
+
+## 1.5.0 - 2022-11-28
+
+### Added
+
+- `Client` can now run IaC scans (gitguardian/ggshield#405).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,9 @@ Line length in the one enforced by Black: 88 characters.
 - The first sentence starts with a capital letter and ends with a point. This sentence is separated from the others by a blank line
 - Docstrings must have :params: if the function has 2 or more arguments.
 - All docstrings must state the return object and raised exception with :return: and :raise:
+
+### Changelog
+
+We use [scriv](https://github.com/nedbat/scriv) to manage our changelog. It is automatically installed by `pipenv install --dev`.
+
+All user visible changes must be documented in a changelog fragment. You can create one with `scriv create`. If your pull request only contains non-visible changes (such as refactors or fixes for regressions introduced _after_ the latest release), then apply the `skip-changelog` label to the pull request.

--- a/Pipfile
+++ b/Pipfile
@@ -17,3 +17,4 @@ pytest = "*"
 vcrpy = "*"
 mypy = "==0.961"
 types-requests = "*"
+scriv = { version = "*", extras = ["toml"] }

--- a/changelog.d/20230327_152427_aurelien.gateau_setup_scriv.md
+++ b/changelog.d/20230327_152427_aurelien.gateau_setup_scriv.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Python dependencies were not correctly defined: py-gitguardian was using `marshmallow-dataclass` and `click` without depending on them. The package now explicitly depends on `marshmallow-dataclass` and does not use `click` anymore (#43).
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,1 @@
+This directory holds changelog entries managed by scriv.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,9 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = ["tests.*", "examples.*"]
 ignore_errors = true
+
+[tool.scriv]
+version = "literal: pygitguardian/__init__.py: __version__"
+format = "md"
+md_header_level = "2"
+insert_marker = "# Changelog"

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+A multi-command tool to automate steps of the release process
+"""
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, List, Union
+
+import click
+
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+ROOT_DIR = Path(__file__).parent.parent
+CHANGELOG_PATH = ROOT_DIR / "CHANGELOG.md"
+INIT_PATH = ROOT_DIR / "pygitguardian" / "__init__.py"
+CASSETTES_DIR = ROOT_DIR / "tests" / "cassettes"
+
+# The branch this script must be run from, except in dev mode.
+RELEASE_BRANCH = "master"
+
+
+def get_version() -> str:
+    from pygitguardian import __version__
+
+    return __version__
+
+
+def get_tag(version: str) -> str:
+    return f"v{version}"
+
+
+def check_run(
+    cmd: List[Union[str, Path]], **kwargs: Any
+) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, text=True, **kwargs)
+
+
+def log_progress(message: str) -> None:
+    click.secho(message, fg="magenta", err=True)
+
+
+def log_error(message: str) -> None:
+    prefix = click.style("ERROR:", fg="red")
+    click.secho(f"{prefix} {message}", err=True)
+
+
+def fail(message: str) -> None:
+    log_error(message)
+    sys.exit(1)
+
+
+def check_working_tree_is_on_release_branch() -> bool:
+    proc = check_run(["git", "branch"], capture_output=True)
+    lines = proc.stdout.splitlines()
+    if f"* {RELEASE_BRANCH}" not in lines:
+        log_error(f"This script must be run on the '{RELEASE_BRANCH}' branch")
+        return False
+    return True
+
+
+def check_working_tree_is_clean() -> bool:
+    proc = check_run(["git", "status", "--porcelain"], capture_output=True)
+    lines = proc.stdout.splitlines()
+    if lines:
+        log_error("Working tree contains changes")
+        return False
+    return True
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--dev-mode",
+    is_flag=True,
+    help=f"Do not abort if the working tree contains changes or if we are not on the '{RELEASE_BRANCH}' branch",
+)
+def main(dev_mode: bool) -> int:
+    """Helper script to release py-gitguardian. Commands should be run in this order:
+
+    \b
+    1. run-tests
+    2. prepare
+    3. tag
+    4. publish-gh-release
+    """
+    checks = (check_working_tree_is_on_release_branch, check_working_tree_is_clean)
+    if not all(x() for x in checks):
+        if dev_mode:
+            log_progress("Ignoring errors because --dev-mode is set")
+        else:
+            fail("Use --dev-mode to ignore")
+
+    return 0
+
+
+@main.command()
+def run_tests() -> None:
+    """Run all tests.
+
+    Unit-tests are run without cassettes. This ensures the recorded cassettes
+    still match production reality.
+    """
+
+    # If CASSETTES_DIR does not exist, tests fail, so recreate it
+    log_progress("Removing cassettes")
+    shutil.rmtree(CASSETTES_DIR)
+    CASSETTES_DIR.mkdir()
+
+    log_progress("Running tests")
+    check_run(["pytest", "tests"], cwd=ROOT_DIR)
+
+    log_progress("Restoring cassettes")
+    check_run(["git", "restore", CASSETTES_DIR], cwd=ROOT_DIR)
+
+
+def replace_once_in_file(path: Path, src: str, dst: str, flags: int = 0) -> None:
+    """Look for `src` in `path`, replace it with `dst`. Abort if no match or more than
+    one were found."""
+    content = path.read_text()
+    content, count = re.subn(src, dst, content, flags=flags)
+    if count != 1:
+        fail(
+            f"Did not make any change to {path}: expected 1 match for '{src}', got {count}."
+        )
+    path.write_text(content)
+
+
+def check_version(version: str) -> None:
+    # Check version is valid
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        fail(f"'{version}' is not a valid version number")
+
+    # Check version does not already exist
+    tag = get_tag(version)
+    proc = check_run(["git", "tag"], capture_output=True)
+    tags = proc.stdout.splitlines()
+    if tag in tags:
+        fail(f"The {tag} tag already exists.")
+
+
+def update_version(version: str) -> None:
+    replace_once_in_file(
+        INIT_PATH,
+        "^__version__ = .*$",
+        f'__version__ = "{version}"',
+        flags=re.MULTILINE,
+    )
+
+
+def update_changelog() -> None:
+    check_run(["scriv", "collect", "--edit"])
+    # prettier and scriv disagree on some minor formatting issue.
+    # Run prettier through pre-commit to fix the CHANGELOG.md.
+    # Do not use `check_run()` here because if prettier reformats the file
+    # (which it will), then the command exit code will be 1.
+    subprocess.run(["pre-commit", "run", "prettier", "--files", CHANGELOG_PATH])
+
+
+def commit_changes(version: str) -> None:
+    check_run(["git", "add", CHANGELOG_PATH, "changelog.d", INIT_PATH])
+    message = f"chore(release): {version}"
+    check_run(["git", "commit", "--message", message])
+
+
+@main.command()
+@click.argument("version")
+def prepare(version: str) -> None:
+    """Prepare the code for the release:
+
+    \b
+    - Bump the version in __init__.py
+    - Update the changelog
+    - Commit changes
+    """
+    check_version(version)
+    update_version(version)
+    update_changelog()
+    commit_changes(version)
+    log_progress(f"Done, review changes and then run `{sys.argv[0]} tag`")
+
+
+@main.command()
+def tag() -> None:
+    """Create the tag for the version, push the main branch and the tag."""
+    version = get_version()
+    tag = get_tag(version)
+    message = f"Releasing {version}"
+    check_run(["git", "tag", "--annotate", tag, "--message", message])
+    check_run(["git", "push", "origin", "main:main", f"{tag}:{tag}"])
+
+
+def get_release_notes(version: str) -> str:
+    """Reads CHANGELOG.md, returns the changes for version `version`, formatted for
+    `gh release`."""
+
+    # Extract changes from CHANGELOG.md
+    changes = CHANGELOG_PATH.read_text()
+    start_match = re.search(
+        f"^## {re.escape(version)} - .*", changes, flags=re.MULTILINE
+    )
+    assert start_match
+    start_pos = start_match.end() + 1
+
+    end_match = re.search("^(<a |## )", changes[start_pos:], flags=re.MULTILINE)
+    assert end_match
+
+    notes = changes[start_pos : end_match.start() + start_pos]
+
+    # Remove one level of indent
+    notes = re.sub("^#", "", notes, flags=re.MULTILINE)
+    return notes.strip()
+
+
+@main.command()
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Do not publish, just print the content of the release notes",
+)
+def publish_gh_release(dry_run: bool = False) -> None:
+    """Set the release notes of the GitHub release, then remove its "draft" status.
+
+    GitHub CLI (https://cli.github.com/) must be installed."""
+
+    version = get_version()
+    tag = get_tag(version)
+
+    notes = get_release_notes(version)
+    if dry_run:
+        print(notes)
+        return
+
+    check_run(
+        [
+            "gh",
+            "release",
+            "edit",
+            tag,
+            "--title",
+            version,
+            "--notes",
+            notes,
+        ]
+    )
+    check_run(["gh", "release", "edit", tag, "--draft=false"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ import vcr
 from pygitguardian import GGClient
 
 
-base_uri = os.environ.get("TEST_LIVE_SERVER_URL", "https://api.gitguardian.com")
-
 my_vcr = vcr.VCR(
     cassette_library_dir=join(dirname(realpath(__file__)), "cassettes"),
     path_transformer=vcr.VCR.ensure_suffix(".yaml"),
@@ -20,11 +18,8 @@ my_vcr = vcr.VCR(
     filter_headers=["Authorization"],
 )
 
-if os.environ.get("TEST_LIVE_SERVER", "false").lower() == "true":
-    my_vcr.record_mode = "all"
-
 
 @pytest.fixture
 def client():
-    api_key = os.environ.get("TEST_LIVE_SERVER_TOKEN", "sample_api_key")
-    return GGClient(base_uri=base_uri, api_key=api_key)
+    api_key = os.environ["GITGUARDIAN_API_KEY"]
+    return GGClient(api_key=api_key)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,7 +18,7 @@ from pygitguardian.config import (
 )
 from pygitguardian.models import Detail, MultiScanResult, QuotaResponse, ScanResult
 
-from .conftest import base_uri, my_vcr
+from .conftest import my_vcr
 
 
 FILENAME = ".env"
@@ -257,7 +257,7 @@ def test_client__url_from_endpoint(base_uries, version, endpoints_and_urls):
         for endpoint, expected_url in endpoints_and_urls:
             assert (
                 client._url_from_endpoint(endpoint, version) == expected_url
-            ), f"Could not get the expected URL for base_uri=`{base_uri}`"
+            ), f"Could not get the expected URL for base_uri=`{curr_base_uri}`"
 
 
 @my_vcr.use_cassette
@@ -371,7 +371,7 @@ def test_multi_content_exceptions(
 @my_vcr.use_cassette
 def test_multi_content_not_ok():
     req = [{"document": "valid"}]
-    client = GGClient(base_uri=base_uri, api_key="invalid")
+    client = GGClient(api_key="invalid")
 
     obj = client.multi_content_scan(req)
 
@@ -383,7 +383,7 @@ def test_multi_content_not_ok():
 @my_vcr.use_cassette
 def test_content_not_ok():
     req = {"document": "valid", "filename": "valid"}
-    client = GGClient(base_uri=base_uri, api_key="invalid")
+    client = GGClient(api_key="invalid")
 
     obj = client.content_scan(**req)
 
@@ -603,7 +603,7 @@ def test_quota_overview(client: GGClient):
         if isinstance(quota_response, QuotaResponse):
             content = quota_response.content
             assert content.count + content.remaining == content.limit
-            assert content.limit == 10000
+            assert content.limit > 0
             assert 2021 <= content.since.year <= date.today().year
         else:
             pytest.fail("returned should be a QuotaResponse")


### PR DESCRIPTION
After these changes, contributors have to use `scriv create` to create changelog fragments. The CI enforces this is the case. One can apply the `skip-changelog` label to pull requests which do not require a changelog fragment (see the latest changes in CONTRIBUTING.md for details).

At release time, the `scripts/release` script uses `scriv` to update the changelog and fill the GitHub release notes.

This is py-gitguardian version of https://github.com/GitGuardian/ggshield/pull/499.
