### PR TITLE
feat(api): always include ignore_known_secrets into the parameter of the multiscan payload

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -317,7 +317,6 @@ class GGClient:
         self,
         documents: List[Dict[str, str]],
         extra_headers: Optional[Dict[str, str]] = None,
-        ignore_known_secrets: Optional[bool] = None,
     ) -> Union[Detail, MultiScanResult]:
         """
         multi_content_scan handles the /multiscan endpoint of the API.
@@ -329,7 +328,6 @@ class GGClient:
         and, optionally, filename.
             example: [{"document":"example content","filename":"intro.py"}]
         :param extra_headers: additional headers to add to the request
-        :param ignore_known_secrets: indicates whether known secrets should be ignored
         :return: Detail or ScanResult response and status code
         """
         if len(documents) > MULTI_DOCUMENT_LIMIT:
@@ -342,16 +340,14 @@ class GGClient:
         else:
             raise TypeError("each document must be a dict")
 
-        params = (
-            {"ignore_known_secrets": ignore_known_secrets}
-            if ignore_known_secrets
-            else {}
-        )
+        # ignore_known_secrets parameter will indicate to include information whether the secret is known by GitGuardian
+        # dashboard
+
         resp = self.post(
             endpoint="multiscan",
             data=request_obj,
             extra_headers=extra_headers,
-            params=params,
+            params={"ignore_known_secrets": True},
         )
 
         obj: Union[Detail, MultiScanResult]

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -206,6 +206,7 @@ class PolicyBreakSchema(BaseSchema):
     policy = fields.String(required=True)
     validity = fields.String(required=False, load_default=None, dump_default=None)
     known_secret = fields.Boolean(required=False, load_default=False, dump_default=None)
+    incident_url = fields.String(required=False, load_default=False, dump_default=None)
     matches = fields.List(fields.Nested(MatchSchema), required=True)
 
     @post_load
@@ -230,6 +231,7 @@ class PolicyBreak(Base):
         validity: str,
         matches: List[Match],
         known_secret: bool = False,
+        incident_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -237,6 +239,7 @@ class PolicyBreak(Base):
         self.policy = policy
         self.validity = validity
         self.known_secret = known_secret
+        self.incident_url = incident_url
         self.matches = matches
 
     @property

--- a/tests/cassettes/max_size_array.yaml
+++ b/tests/cassettes/max_size_array.yaml
@@ -21,7 +21,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.3.4 (Linux;py3.8.10)
       method: POST
-      uri: https://api.gitguardian.com/v1/multiscan
+      uri: https://api.gitguardian.com/v1/multiscan?ignore_known_secrets=True
     response:
       body:
         string:

--- a/tests/cassettes/test_multi_content_not_ok.yaml
+++ b/tests/cassettes/test_multi_content_not_ok.yaml
@@ -15,7 +15,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.3.4 (Linux;py3.8.10)
       method: POST
-      uri: https://api.gitguardian.com/v1/multiscan
+      uri: https://api.gitguardian.com/v1/multiscan?ignore_known_secrets=True
     response:
       body:
         string: '{"detail":"Invalid API key."}'

--- a/tests/cassettes/with_breaks.yaml
+++ b/tests/cassettes/with_breaks.yaml
@@ -20,7 +20,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.3.4 (Linux;py3.8.10)
       method: POST
-      uri: https://api.gitguardian.com/v1/multiscan
+      uri: https://api.gitguardian.com/v1/multiscan?ignore_known_secrets=True
     response:
       body:
         string:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -586,7 +586,6 @@ def test_multiscan_parameters(
 
     client.multi_content_scan(
         [{"filename": FILENAME, "document": DOCUMENT}],
-        ignore_known_secrets=True,
     )
 
     assert request_mock.called


### PR DESCRIPTION
This parameter will tell gitguardian backend to include information about whether the secret is known to the dashboard