### PR TITLE
feat(api): parse incident_url from the multiscan endpoint

### DIFF
--- a/changelog.d/20230403_154257_alina.tuholukova_include_incident_url.md
+++ b/changelog.d/20230403_154257_alina.tuholukova_include_incident_url.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- PolicyBreak now includes the URL of the policy break if the dashboard already knows about it.
+
+<!--
+### Changed
+
+- A bullet item for the Deprecated category.
+
+-->
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -206,6 +206,7 @@ class PolicyBreakSchema(BaseSchema):
     policy = fields.String(required=True)
     validity = fields.String(required=False, load_default=None, dump_default=None)
     known_secret = fields.Boolean(required=False, load_default=False, dump_default=None)
+    incident_url = fields.String(required=False, load_default=False, dump_default=None)
     matches = fields.List(fields.Nested(MatchSchema), required=True)
 
     @post_load
@@ -230,6 +231,7 @@ class PolicyBreak(Base):
         validity: str,
         matches: List[Match],
         known_secret: bool = False,
+        incident_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -237,6 +239,7 @@ class PolicyBreak(Base):
         self.policy = policy
         self.validity = validity
         self.known_secret = known_secret
+        self.incident_url = incident_url
         self.matches = matches
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -92,6 +92,18 @@ class TestModel:
                 },
             ),
             (
+                PolicyBreakSchema,
+                PolicyBreak,
+                {
+                    "type": "hello",
+                    "policy": "hello",
+                    "validity": "hey",
+                    "known_secret": True,
+                    "incident_url": "https://api.gitguardian.com/workspace/2/incidents/3",
+                    "matches": [{"match": "hello", "type": "hello"}],
+                },
+            ),
+            (
                 QuotaSchema,
                 Quota,
                 {


### PR DESCRIPTION
incident_url is included when the secret of a policy break is known by a dashboard