### PR TITLE
Improve tests

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pipenv run coverage run --source pygitguardian -m pytest --disable-pytest-warnings
+          pipenv run coverage run --source pygitguardian -m pytest
           pipenv run coverage report --fail-under=80
           pipenv run coverage xml
         env:

--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ urllib3 = "<2" # pin until https://github.com/kevin1024/vcrpy/issues/688 is fixe
 mypy = "==0.961"
 types-requests = "*"
 scriv = { version = "*", extras = ["toml"] }
+responses = ">=0.23.1,<0.24.0"

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -505,7 +505,7 @@ class HoneytokenResponseSchema(BaseSchema):
     revoker_id = fields.Int(allow_none=True)
     creator_api_token_id = fields.String(allow_none=True)
     revoker_api_token_id = fields.String(allow_none=True)
-    token = fields.Mapping(key=fields.String(), value=fields.String())
+    token = fields.Mapping(fields.String(), fields.String())
     tags = fields.List(fields.String())
 
     @post_load


### PR DESCRIPTION
This PR does some house-keeping in py-gitguardian tests:

## Better mocks

Switch to [responses](https://pypi.org/project/responses/) to mock `requests` responses. This makes mocks closer to the real classes than our home-made mocks. It was required by an upcoming change to make `GGClient.request()` log the received HTTP status code. Adding this log caused the tests to fail because the mocked responses did not have a `status_code` field.

## No warnings

Fix a Marshmallow deprecation warning in the tests:

```
../../.local/share/virtualenvs/py-gitguardian-n9b0MJaw/lib/python3.10/site-packages/marshmallow/fields.py:1571
  /home/agateau/.local/share/virtualenvs/py-gitguardian-n9b0MJaw/lib/python3.10/site-packages/marshmallow/fields.py:1571: RemovedInMarshmallow4Warning: Passing field metadata as keyword arguments is deprecated. Use the explicit `metadata=...` argument instead. Additional metadata: {'key': <fields.String(dump_default=<marshmallow.missing>, attribute=None, validate=None, required=False, load_only=False, dump_only=False, load_default=<marshmallow.missing>, allow_none=False, error_messages={'required': 'Missing data for required field.', 'null': 'Field may not be null.', 'validator_failed': 'Invalid value.', 'invalid': 'Not a valid string.', 'invalid_utf8': 'Not a valid utf-8 string.'})>, 'value': <fields.String(dump_default=<marshmallow.missing>, attribute=None, validate=None, required=False, load_only=False, dump_only=False, load_default=<marshmallow.missing>, allow_none=False, error_messages={'required': 'Missing data for required field.', 'null': 'Field may not be null.', 'validator_failed': 'Invalid value.', 'invalid': 'Not a valid string.', 'invalid_utf8': 'Not a valid utf-8 string.'})>}
    super().__init__(**kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This warning was not visible because the test suite was running with `--disable-pytest-warnings`, so remove that flag too.