### PR TITLE
Switch to pyright, complete type-hinting

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipenv==2022.10.4 pre-commit
-          pipenv install --system --skip-lock
+          pipenv install --dev --skip-lock
 
       - uses: actions/cache@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,17 @@ repos:
     hooks:
       - id: flake8
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+  # use a "local" repo and not the pyright hook to ensure pyright runs in the same virtualenv
+  # as the rest of the code
+  - repo: local
     hooks:
-      - id: mypy
-        additional_dependencies: [types-requests]
+      - id: pyright
+        name: pyright
+        entry: 'pipenv run pyright'
+        language: system
+        types: [python]
+        # do not pass filenames, otherwise Pyright might scan files we don't want it to scan
+        pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include pygitguardian/py.typed

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ pre-commit = "*"
 pytest = "*"
 vcrpy = ">=4.3.0,!=4.3.1,<4.4.0"  # v4.3.1 broke decode_compressed_response
 urllib3 = "<2" # pin until https://github.com/kevin1024/vcrpy/issues/688 is fixed
-mypy = "==0.961"
-types-requests = "*"
 scriv = { version = "*", extras = ["toml"] }
 responses = ">=0.23.1,<0.24.0"
+pyright = "==1.1.313"

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -19,6 +19,7 @@ from .iac_models import (
 from .models import (
     Detail,
     Document,
+    DocumentSchema,
     HealthCheckResponse,
     HoneytokenResponse,
     MultiScanResult,
@@ -252,7 +253,7 @@ class GGClient:
     def post(
         self,
         endpoint: str,
-        data: Optional[Dict[str, Any]] = None,
+        data: Union[Dict[str, Any], List[Dict[str, Any]], None] = None,
         version: str = DEFAULT_API_VERSION,
         extra_headers: Optional[Dict[str, str]] = None,
         **kwargs: Any,
@@ -307,7 +308,7 @@ class GGClient:
             doc_dict["filename"] = filename
 
         request_obj = Document.SCHEMA.load(doc_dict)
-        Document.SCHEMA.validate_size(
+        DocumentSchema.validate_size(
             request_obj, self.secret_scan_preferences.maximum_document_size
         )
 
@@ -358,7 +359,7 @@ class GGClient:
             raise TypeError("each document must be a dict")
 
         for document in request_obj:
-            Document.SCHEMA.validate_size(
+            DocumentSchema.validate_size(
                 document, self.secret_scan_preferences.maximum_document_size
             )
 

--- a/pygitguardian/iac_models.py
+++ b/pygitguardian/iac_models.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Type, cast
 
 import marshmallow_dataclass
 
-from pygitguardian.models import Base, BaseSchema
+from pygitguardian.models import Base, BaseSchema, FromDictMixin
 
 
 @dataclass
-class IaCVulnerability(Base):
+class IaCVulnerability(Base, FromDictMixin):
     policy: str
     policy_id: str
     line_end: int
@@ -18,37 +18,48 @@ class IaCVulnerability(Base):
     severity: str = ""
 
 
-IaCVulnerabilitySchema = marshmallow_dataclass.class_schema(
-    IaCVulnerability, BaseSchema
+IaCVulnerabilitySchema = cast(
+    Type[BaseSchema], marshmallow_dataclass.class_schema(IaCVulnerability, BaseSchema)
 )
+
+IaCVulnerability.SCHEMA = IaCVulnerabilitySchema()
 
 
 @dataclass
-class IaCFileResult(Base):
+class IaCFileResult(Base, FromDictMixin):
     filename: str
     incidents: List[IaCVulnerability]
 
 
-IaCFileResultSchema = marshmallow_dataclass.class_schema(IaCFileResult, BaseSchema)
+IaCFileResultSchema = cast(
+    Type[BaseSchema], marshmallow_dataclass.class_schema(IaCFileResult, BaseSchema)
+)
+
+IaCFileResult.SCHEMA = IaCFileResultSchema()
 
 
 @dataclass
-class IaCScanParameters(Base):
+class IaCScanParameters(Base, FromDictMixin):
     ignored_policies: List[str] = field(default_factory=list)
     minimum_severity: Optional[str] = None
 
 
-IaCScanParametersSchema = marshmallow_dataclass.class_schema(
-    IaCScanParameters, BaseSchema
+IaCScanParametersSchema = cast(
+    Type[BaseSchema], marshmallow_dataclass.class_schema(IaCScanParameters, BaseSchema)
 )
+
+IaCScanParameters.SCHEMA = IaCScanParametersSchema()
 
 
 @dataclass
-class IaCScanResult(Base):
+class IaCScanResult(Base, FromDictMixin):
     id: str = ""
     type: str = ""
     iac_engine_version: str = ""
     entities_with_incidents: List[IaCFileResult] = field(default_factory=list)
 
 
-IaCScanResultSchema = marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)
+IaCScanResultSchema = cast(
+    Type[BaseSchema], marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)
+)
+IaCScanResult.SCHEMA = IaCScanResultSchema()

--- a/pygitguardian/py.typed
+++ b/pygitguardian/py.typed
@@ -1,0 +1,2 @@
+# PEP-561 Support File.
+# "Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,26 +6,8 @@ line-length = 88
 profile = "black"
 lines_after_imports = 2
 
-[tool.mypy]
-python_version = "3.9"
-warn_return_any = true
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-follow_imports = "silent"
-ignore_missing_imports = true
-no_implicit_optional = true
-strict_equality = true
-strict_optional = true
-warn_incomplete_stub = true
-warn_redundant_casts = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-module = ["tests.*", "examples.*"]
-ignore_errors = true
+[tool.pyright]
+include = ["pygitguardian"]
 
 [tool.scriv]
 version = "literal: pygitguardian/__init__.py: __version__"

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "marshmallow>=3.5, <4",
         "requests>=2, <3",
         "marshmallow-dataclass >=8.5.8, <8.6.0",
+        "typing-extensions",
     ],
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
## Description

This PR improves type-safety by doing two things:

### Switch to pyright

Switches to pyright, which catches more errors. As a result I had to introduce 2 mixins to make Marshmallow code more type-safe: `FromDictMixin` provides a `from_dict()` method, `ToDictMixin` provides the matching `to_dict()` method.

Code which previously deserialized objects using `<Class>.SCHEMA.load(dct)` now use `<Class>.from_dict(dct)`.

`Base` inherits from `ToDictMixin`, but not from `FromDictMixin` because unfortunately some of our classes do not deserialize to objects and changing that would break API compatibility. This is the case for `Document` and `HealthCheckResponse`.

### Mark the package as type-hinted

Installs a `py.typed` marker file so that type-checkers running on packages using py-gitguardian knows the package has type-hints.
