### PR TITLE
fix: change request param to accept data

### DIFF
--- a/changelog.d/20230622_100420_sylvain.baud.ext_fix_request_data_field.md
+++ b/changelog.d/20230622_100420_sylvain.baud.ext_fix_request_data_field.md
@@ -1,0 +1,3 @@
+### Fix
+
+- Fixed GGClient.iac_directory_scan to make it able to send a request with a data key.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -269,6 +269,7 @@ class GGClient:
         extra_headers: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> Response:
+        # Be aware that self.iac_directory_scan bypass this method and calls self.request directly.
         return self.request(
             "post",
             endpoint=endpoint,
@@ -472,7 +473,9 @@ class GGClient:
         tar = _create_tar(directory, filenames)
         result: Union[Detail, IaCScanResult]
         try:
-            resp = self.post(
+            # bypass self.post because data argument is needed in self.request and self.post use it as json
+            resp = self.request(
+                "post",
                 endpoint="iac_scan",
                 extra_headers=extra_headers,
                 files={


### PR DESCRIPTION
GGClient `iac_directory_scan` method called the GGClient `post` method with the argument `data`.
It expected the data argument to be used in request .request with a key `data`. 
However post processed the `data` argument and used it in request.request with a key `json`.

Therefore I renamed the argument `data` to `json` to avoid confusion and free the `data` argument to be used with the `data` key.