### PR TITLE
Improve create_jwt() test

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -751,6 +751,14 @@ def test_create_jwt(
     """
     mock_response = responses.post(
         url=client._url_from_endpoint("auth/jwt", "v1"),
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "audience": "dummy_audience",
+                    "audience_type": "hmsl",
+                }
+            )
+        ],
         content_type="application/json",
         status=200,
         json={"token": "dummy_token"},


### PR DESCRIPTION
The test for `GGClient.create_jwt()` did not fail in #63 as I expected it to. This PR makes the test more picky so it would have failed with the initial change from #63.