### PR TITLE
Sbaud/iac diff scan

### DIFF
--- a/changelog.d/20230703_154225_sylvain.baud.ext_iac_diff_scan.md
+++ b/changelog.d/20230703_154225_sylvain.baud.ext_iac_diff_scan.md
@@ -1,0 +1,3 @@
+### Added
+
+- `iac_diff_scan` added to GGClient. This allows scanning two directories for IaC vulnerabilities and categorise incidents as new, unchanged or deleted.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -468,7 +468,6 @@ class GGClient:
             result.status_code = resp.status_code
         return result
 
-    # For IaC Scans
     def iac_directory_scan(
         self,
         directory: Path,
@@ -476,6 +475,16 @@ class GGClient:
         scan_parameters: IaCScanParameters,
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, IaCScanResult]:
+        """
+        iac_directory_scan handles the /iac_scan endpoint of the API.
+
+        :param directory: path to the directory to scan
+        :param filenames: filenames of the directory to include in the scan
+        :param scan_parameters: minimum severities wanted and policies to ignore
+            example: {"ignored_policies":["GG_IAC_0003"],"minimum_severity":"HIGH"}
+        :param extra_headers: optional extra headers to add to the request
+        :return: ScanResult response and status code
+        """
         tar = _create_tar(directory, filenames)
         result: Union[Detail, IaCScanResult]
         try:
@@ -504,7 +513,6 @@ class GGClient:
 
         return result
 
-    # For IaC diff Scans
     def iac_diff_scan(
         self,
         reference: bytes,
@@ -512,6 +520,21 @@ class GGClient:
         scan_parameters: IaCScanParameters,
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, IaCDiffScanResult]:
+        """
+        iac_diff_scan handles the /iac_diff_scan endpoint of the API.
+
+        Scan two directories and compare their vulnerabilities.
+        Vulnerabilities in reference but not in current are considered "new".
+        Vulnerabilities in both reference and current are considered "unchanged".
+        Vulnerabilities in current but not in reference are considered "deleted".
+
+        :param reference: tar file containing the reference directory. Usually an incoming commit
+        :param current: tar file of the current directory. Usually HEAD
+        :param scan_parameters: minimum severities wanted and policies to ignore
+            example: {"ignored_policies":["GG_IAC_0003"],"minimum_severity":"HIGH"}
+        :param extra_headers: optional extra headers to add to the request
+        :return: ScanResult response and status code
+        """
         result: Union[Detail, IaCDiffScanResult]
         try:
             # bypass self.post because data argument is needed in self.request and self.post use it as json

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -14,7 +14,6 @@ from requests import Response, Session, codes
 from .config import DEFAULT_API_VERSION, DEFAULT_BASE_URI, DEFAULT_TIMEOUT
 from .iac_models import (
     IaCDiffScanResult,
-    IaCDiffScanResultSchema,
     IaCScanParameters,
     IaCScanParametersSchema,
     IaCScanResult,
@@ -533,7 +532,7 @@ class GGClient:
             result.status_code = 504
         else:
             if is_ok(resp):
-                result = IaCDiffScanResultSchema.from_dict(resp.json())  # type: ignore
+                result = IaCDiffScanResult.from_dict(resp.json())
             else:
                 result = load_detail(resp)
 

--- a/pygitguardian/iac_models.py
+++ b/pygitguardian/iac_models.py
@@ -63,3 +63,25 @@ IaCScanResultSchema = cast(
     Type[BaseSchema], marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)
 )
 IaCScanResult.SCHEMA = IaCScanResultSchema()
+
+
+@dataclass
+class IaCDiffScanEntities(Base):
+    unchanged: List[IaCFileResult] = field(default_factory=list)
+    new: List[IaCFileResult] = field(default_factory=list)
+    deleted: List[IaCFileResult] = field(default_factory=list)
+
+
+@dataclass
+class IaCDiffScanResult(Base):
+    id: str = ""
+    type: str = ""
+    iac_engine_version: str = ""
+    entities_with_incidents: IaCDiffScanEntities = field(
+        default_factory=IaCDiffScanEntities
+    )
+
+
+IaCDiffScanResultSchema = marshmallow_dataclass.class_schema(
+    IaCDiffScanResult, BaseSchema
+)

--- a/pygitguardian/iac_models.py
+++ b/pygitguardian/iac_models.py
@@ -73,7 +73,7 @@ class IaCDiffScanEntities(Base):
 
 
 @dataclass
-class IaCDiffScanResult(Base):
+class IaCDiffScanResult(Base, FromDictMixin):
     id: str = ""
     type: str = ""
     iac_engine_version: str = ""
@@ -82,6 +82,7 @@ class IaCDiffScanResult(Base):
     )
 
 
-IaCDiffScanResultSchema = marshmallow_dataclass.class_schema(
-    IaCDiffScanResult, BaseSchema
+IaCDiffScanResultSchema = cast(
+    Type[BaseSchema], marshmallow_dataclass.class_schema(IaCDiffScanResult, BaseSchema)
 )
+IaCDiffScanResult.SCHEMA = IaCDiffScanResultSchema()


### PR DESCRIPTION
Add iac diff scan to pyGitGuardian.

We use the same implementation logic than iac directory scan.

Careful, just like iac directory scan, iac diff scan needs to access the data argument of request. Therefore iac_diff_scan bypass the GGClient.post method and directly call GGClient.request.