### PR TITLE
Pin urllib3 to prevent bad dependencies resolving on MacOS with Python3.10

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ isort = "*"
 pre-commit = "*"
 pytest = "*"
 vcrpy = ">=4.3.0,!=4.3.1,<4.4.0"  # v4.3.1 broke decode_compressed_response
-urllib3 = "<2" # pin until https://github.com/kevin1024/vcrpy/issues/688 is fixed
+urllib3 = "1.26.16" # pin until https://github.com/kevin1024/vcrpy/issues/688 is fixed
 scriv = { version = "*", extras = ["toml"] }
 responses = ">=0.23.1,<0.24.0"
 pyright = "==1.1.313"


### PR DESCRIPTION
For an unknown reason, dependencies installation results in urllib3 not being below version 3 on MacOS with Python3.10.
Actually, worse than that: the install is flaky...