### PR TITLE
Handle API rate-limits

### DIFF
--- a/changelog.d/20231221_170806_aurelien.gateau_report_rate_limit.md
+++ b/changelog.d/20231221_170806_aurelien.gateau_report_rate_limit.md
@@ -1,0 +1,3 @@
+### Added
+
+- GGClient now obeys rate-limits and can notify callers when hitting one.

--- a/pygitguardian/__init__.py
+++ b/pygitguardian/__init__.py
@@ -1,8 +1,8 @@
 """PyGitGuardian API Client"""
-from .client import ContentTooLarge, GGClient
+from .client import ContentTooLarge, GGClient, GGClientCallbacks
 
 
 __version__ = "1.11.0"
 GGClient._version = __version__
 
-__all__ = ["GGClient", "ContentTooLarge"]
+__all__ = ["GGClient", "GGClientCallbacks", "ContentTooLarge"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 from os.path import dirname, join, realpath
+from typing import Any
 
 import pytest
 import vcr
@@ -19,7 +20,12 @@ my_vcr = vcr.VCR(
 )
 
 
+def create_client(**kwargs: Any) -> GGClient:
+    """Create a GGClient using $GITGUARDIAN_API_KEY"""
+    api_key = os.environ["GITGUARDIAN_API_KEY"]
+    return GGClient(api_key=api_key, **kwargs)
+
+
 @pytest.fixture
 def client():
-    api_key = os.environ["GITGUARDIAN_API_KEY"]
-    return GGClient(api_key=api_key)
+    return create_client()


### PR DESCRIPTION
## Context

We want to apply rate-limits to the GitGuardian server endpoints used by GGShield. To be able to do so, py-gitguardian must be able to:
- identify a rate-limit error
- wait the appropriate delay and retry
- notify callers that we are rate-limited

## What has been done

This PR introduces a new abstract class, `GGClientCallbacks`. A caller interested in getting notified of rate-limit events must:
- Implement the `GGClientCallbacks` abstract class
- Pass an instance of it when creating a `GGClient` instance
