### PR TITLE
Post-release fixes

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pipenv==2022.10.4 pre-commit
+          python -m pip install --upgrade pipenv==2023.10.3 pre-commit
           pipenv install --dev --skip-lock
 
       - uses: actions/cache@v3
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
 
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pipenv==2022.10.4
+          python -m pip install --upgrade pipenv==2023.10.3
           pipenv install --system --dev --skip-lock
 
       - name: Test with pytest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -105,7 +105,7 @@ jobs:
           echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -116,7 +116,7 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Minor CI fixes following the release:
- Update some GitHub actions to the latest version (and pin pypa/gh-action-pypi-publish which was still using master, which is deprecated)
- Add Python 3.12 to our test matrix