### PR TITLE
feat(sca): add input scan parameters to ignore vulns

### DIFF
--- a/pygitguardian/sca_models.py
+++ b/pygitguardian/sca_models.py
@@ -33,6 +33,8 @@ SCAIgnoredVulnerability.SCHEMA = cast(
 class SCAScanParameters(Base, FromDictMixin):
     minimum_severity: Optional[str] = None
     ignored_vulnerabilities: List[SCAIgnoredVulnerability] = field(default_factory=list)
+    ignore_no_fix: bool = False
+    ignore_fix_available: bool = False
 
 
 SCAScanParameters.SCHEMA = cast(

--- a/tests/test_sca_models.py
+++ b/tests/test_sca_models.py
@@ -26,13 +26,21 @@ class TestModel:
             (
                 SCAScanParameters,
                 {
-                    "miniumu_severity": "LOW",
+                    "minimum_severity": "LOW",
                     "ignored_vulnerabilities": [
                         {
                             "identifier": "GHSA-toto",
                             "path": "Pipfile",
                         }
                     ],
+                    "ignore_fix_available": True,
+                    "ignore_no_fix": False,
+                },
+            ),
+            (
+                SCAScanParameters,
+                {
+                    "ignore_no_fix": True,
                 },
             ),
             (


### PR DESCRIPTION
Issue: SCA-1345

- Adds `ignore_no_fix` and `ignore_fix_available` scan parameters in SCA models.