### PR TITLE
Bump black to 24.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3

--- a/pygitguardian/__init__.py
+++ b/pygitguardian/__init__.py
@@ -1,4 +1,5 @@
 """PyGitGuardian API Client"""
+
 from .client import ContentTooLarge, GGClient, GGClientCallbacks
 
 


### PR DESCRIPTION
Update Black to 24.3.0 to fix [CVE-2024-21503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21503).