### PR TITLE
Improve error handling

### DIFF
--- a/changelog.d/20240514_143905_aurelien.gateau_improve_error_handling.md
+++ b/changelog.d/20240514_143905_aurelien.gateau_improve_error_handling.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- GGClient no longer crashes when it receives an odd server response, like a response with no Content-Type header.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -82,7 +82,7 @@ def load_detail(resp: Response) -> Detail:
     :return: detail object of response
     :rtype: Detail
     """
-    if resp.headers["content-type"] == "application/json":
+    if resp.headers.get("content-type") == "application/json":
         data = resp.json()
     else:
         data = {"detail": resp.text}
@@ -96,7 +96,7 @@ def is_ok(resp: Response) -> bool:
     and the content type is JSON.
     """
     return (
-        resp.headers["content-type"] == "application/json"
+        resp.headers.get("content-type") == "application/json"
         and resp.status_code == codes.ok
     )
 
@@ -107,7 +107,7 @@ def is_create_ok(resp: Response) -> bool:
     and the content type is JSON.
     """
     return (
-        resp.headers["content-type"] == "application/json"
+        resp.headers.get("content-type") == "application/json"
         and resp.status_code == codes.created
     )
 


### PR DESCRIPTION
This PR improves how we handle server responses by not assuming it is going to include a `Content-Type` header. This makes GGClient more robust in contexts where network responses are generated by tools like firewalls.
