### PR TITLE
Fix release job

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -125,10 +125,9 @@ jobs:
           python-version: '3.x'
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade build
       - name: Build distribution
-        run: >-
-          python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/changelog.d/20240624_103236_aurelien.gateau_fix_release_job.md
+++ b/changelog.d/20240624_103236_aurelien.gateau_fix_release_job.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix release CI job failure.


### PR DESCRIPTION
## Context

Now that py-gitguardian uses pdm, it no longer has a setup.py. This caused the "release" job to fail.

## What has been done

Switch to using `build` to create the release sdist and wheel.

Tested by adding a fake release job which ran the same commands as the "release" job. The result of the fake job can be seen [here](https://github.com/GitGuardian/py-gitguardian/actions/runs/9642297578/job/26589890381), but it was created in a separate commit which I have now reverted.
