### PR TITLE
Fix release step using wrong version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygitguardian"
-version = "1.14.0"
+dynamic = ['version']
 description = "Python Wrapper for GitGuardian's API -- Scan security policy breaks everywhere"
 keywords = [
     "api-client devsecops secrets-detection security-tools library gitguardian",
@@ -59,6 +59,10 @@ dev = [
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
+
+[tool.pdm.version]
+source = "file"
+path = "pygitguardian/__init__.py"
 
 [tool.black]
 target-version = ['py39']


### PR DESCRIPTION
Do not hardcode version number in pyproject.toml: read it from `pygitguardian/__init__.py` instead.

This caused the [release to fail](https://github.com/GitGuardian/py-gitguardian/actions/runs/9642972539/job/26592043917) because it created a 1.14.0 wheel.

Should have caught that in the previous fix 🤦🏻.
