### PR TITLE
Add remediation messages to GGclient

### DIFF
--- a/changelog.d/20240701_180056_fnareoh_scrt_4626_ggshield_display_custom_remediation_message_in_ggshield_if.md
+++ b/changelog.d/20240701_180056_fnareoh_scrt_4626_ggshield_display_custom_remediation_message_in_ggshield_if.md
@@ -1,0 +1,3 @@
+### Added
+
+- GGClient now contains remediation messages obtained from the API `/metadata` endpoint.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -35,6 +35,7 @@ from .models import (
     JWTService,
     MultiScanResult,
     QuotaResponse,
+    RemediationMessages,
     ScanResult,
     SecretScanPreferences,
     ServerMetadata,
@@ -151,6 +152,7 @@ class GGClient:
     user_agent: str
     extra_headers: Dict
     secret_scan_preferences: SecretScanPreferences
+    remediation_messages: RemediationMessages
     callbacks: Optional[GGClientCallbacks]
 
     def __init__(
@@ -214,6 +216,7 @@ class GGClient:
         )
         self.maximum_payload_size = MAXIMUM_PAYLOAD_SIZE
         self.secret_scan_preferences = SecretScanPreferences()
+        self.remediation_messages = RemediationMessages()
 
     def request(
         self,
@@ -676,6 +679,7 @@ class GGClient:
             "general__maximum_payload_size", MAXIMUM_PAYLOAD_SIZE
         )
         self.secret_scan_preferences = metadata.secret_scan_preferences
+        self.remediation_messages = metadata.remediation_messages
         return None
 
     def create_jwt(

--- a/pygitguardian/config.py
+++ b/pygitguardian/config.py
@@ -5,3 +5,51 @@ DEFAULT_TIMEOUT = 20.0  # 20s default timeout
 MULTI_DOCUMENT_LIMIT = 20
 DOCUMENT_SIZE_THRESHOLD_BYTES = 1048576  # 1MB
 MAXIMUM_PAYLOAD_SIZE = 2621440  # 25MB
+
+
+DEFAULT_REWRITE_GIT_HISTORY_MESSAGE = """
+  To prevent having to rewrite git history in the future, setup ggshield as a pre-commit hook:
+    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit
+"""
+
+DEFAULT_PRE_COMMIT_MESSAGE = """> How to remediate
+
+  Since the secret was detected before the commit was made:
+  1. replace the secret with its reference (e.g. environment variable).
+  2. commit again.
+
+> [To apply with caution] If you want to bypass ggshield (false positive or other reason), run:
+  - if you use the pre-commit framework:
+
+    SKIP=ggshield git commit -m "<your message>"""
+
+DEFAULT_PRE_PUSH_MESSAGE = (
+    """> How to remediate
+
+  Since the secret was detected before the push BUT after the commit, you need to:
+  1. rewrite the git history making sure to replace the secret with its reference (e.g. environment variable).
+  2. push again.
+"""
+    + DEFAULT_REWRITE_GIT_HISTORY_MESSAGE
+    + """
+> [To apply with caution] If you want to bypass ggshield (false positive or other reason), run:
+  - if you use the pre-commit framework:
+
+    SKIP=ggshield-push git push"""
+)
+
+DEFAULT_PRE_RECEIVE_MESSAGE = (
+    """> How to remediate
+
+  A pre-receive hook set server side prevented you from pushing secrets.
+
+  Since the secret was detected during the push BUT after the commit, you need to:
+  1. rewrite the git history making sure to replace the secret with its reference (e.g. environment variable).
+  2. push again.
+"""
+    + DEFAULT_REWRITE_GIT_HISTORY_MESSAGE
+    + """
+> [To apply with caution] If you want to bypass ggshield (false positive or other reason), run:
+
+    git push -o breakglass"""
+)

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -19,7 +19,13 @@ from marshmallow import (
 )
 from typing_extensions import Self
 
-from .config import DOCUMENT_SIZE_THRESHOLD_BYTES, MULTI_DOCUMENT_LIMIT
+from .config import (
+    DEFAULT_PRE_COMMIT_MESSAGE,
+    DEFAULT_PRE_PUSH_MESSAGE,
+    DEFAULT_PRE_RECEIVE_MESSAGE,
+    DOCUMENT_SIZE_THRESHOLD_BYTES,
+    MULTI_DOCUMENT_LIMIT,
+)
 
 
 class ToDictMixin:
@@ -735,11 +741,21 @@ class SecretScanPreferences:
 
 
 @dataclass
+class RemediationMessages:
+    pre_commit: str = DEFAULT_PRE_COMMIT_MESSAGE
+    pre_push: str = DEFAULT_PRE_PUSH_MESSAGE
+    pre_receive: str = DEFAULT_PRE_RECEIVE_MESSAGE
+
+
+@dataclass
 class ServerMetadata(Base, FromDictMixin):
     version: str
     preferences: Dict[str, Any]
     secret_scan_preferences: SecretScanPreferences = field(
         default_factory=SecretScanPreferences
+    )
+    remediation_messages: RemediationMessages = field(
+        default_factory=RemediationMessages
     )
 
 


### PR DESCRIPTION
This MR add a new dataclass `RemediationMessages` used in the `GGClient` to store information given by the metadata endpoint and if the remediation message are not part of the API answer the default are used.

This change is meant to be used with https://github.com/GitGuardian/ggshield/pull/928 . 