### PR TITLE
handle excluded policy breaks

### DIFF
--- a/changelog.d/20241014_101918_mathias.millet_handle_excluded_policy_breaks.md
+++ b/changelog.d/20241014_101918_mathias.millet_handle_excluded_policy_breaks.md
@@ -19,6 +19,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Changed
 
+- `content_scan` and `multi_content_scan` now accept `all_secrets` parameter.
 - `PolicyBreak` now contains two new fields: `is_excluded` and `exclude_reason`.
 <!--
 

--- a/changelog.d/20241014_101918_mathias.millet_handle_excluded_policy_breaks.md
+++ b/changelog.d/20241014_101918_mathias.millet_handle_excluded_policy_breaks.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- `PolicyBreak` now contains two new fields: `is_excluded` and `exclude_reason`.
+<!--
+
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -358,6 +358,8 @@ class GGClient:
         document: str,
         filename: Optional[str] = None,
         extra_headers: Optional[Dict[str, str]] = None,
+        *,
+        all_secrets: Optional[bool] = None,
     ) -> Union[Detail, ScanResult]:
         """
         content_scan handles the /scan endpoint of the API.
@@ -368,6 +370,7 @@ class GGClient:
         :param filename: name of file, example: "intro.py"
         :param document: content of file
         :param extra_headers: additional headers to add to the request
+        :param all_secrets: indicates whether all secrets should be returned
         :return: Detail or ScanResult response and status code
         """
 
@@ -379,11 +382,15 @@ class GGClient:
         DocumentSchema.validate_size(
             request_obj, self.secret_scan_preferences.maximum_document_size
         )
+        params = {}
+        if all_secrets is not None:
+            params["all_secrets"] = all_secrets
 
         resp = self.post(
             endpoint="scan",
             data=request_obj,
             extra_headers=extra_headers,
+            params=params,
         )
 
         obj: Union[Detail, ScanResult]
@@ -401,6 +408,8 @@ class GGClient:
         documents: List[Dict[str, str]],
         extra_headers: Optional[Dict[str, str]] = None,
         ignore_known_secrets: Optional[bool] = None,
+        *,
+        all_secrets: Optional[bool] = None,
     ) -> Union[Detail, MultiScanResult]:
         """
         multi_content_scan handles the /multiscan endpoint of the API.
@@ -413,6 +422,7 @@ class GGClient:
             example: [{"document":"example content","filename":"intro.py"}]
         :param extra_headers: additional headers to add to the request
         :param ignore_known_secrets: indicates whether known secrets should be ignored
+        :param all_secrets: indicates whether all secrets should be returned
         :return: Detail or ScanResult response and status code
         """
         max_documents = self.secret_scan_preferences.maximum_documents_per_scan
@@ -433,11 +443,12 @@ class GGClient:
                 document, self.secret_scan_preferences.maximum_document_size
             )
 
-        params = (
-            {"ignore_known_secrets": ignore_known_secrets}
-            if ignore_known_secrets
-            else {}
-        )
+        params = {}
+        if ignore_known_secrets is not None:
+            params["ignore_known_secrets"] = ignore_known_secrets
+        if all_secrets is not None:
+            params["all_secrets"] = all_secrets
+
         resp = self.post(
             endpoint="multiscan",
             data=request_obj,

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -260,7 +260,7 @@ class PolicyBreakSchema(BaseSchema):
     policy = fields.String(required=True)
     validity = fields.String(required=False, load_default=None, dump_default=None)
     known_secret = fields.Boolean(required=False, load_default=False, dump_default=None)
-    incident_url = fields.String(required=False, load_default=False, dump_default=None)
+    incident_url = fields.String(required=False, load_default=None, dump_default=None)
     matches = fields.List(fields.Nested(MatchSchema), required=True)
 
     @post_load

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -262,6 +262,8 @@ class PolicyBreakSchema(BaseSchema):
     known_secret = fields.Boolean(required=False, load_default=False, dump_default=None)
     incident_url = fields.String(required=False, load_default=None, dump_default=None)
     matches = fields.List(fields.Nested(MatchSchema), required=True)
+    is_excluded = fields.Boolean(required=False, load_default=False, dump_default=False)
+    exclude_reason = fields.String(required=False, load_default=None, dump_default=None)
 
     @post_load
     def make_policy_break(self, data: Dict[str, Any], **kwargs: Any) -> "PolicyBreak":
@@ -286,6 +288,8 @@ class PolicyBreak(Base, FromDictMixin):
         matches: List[Match],
         known_secret: bool = False,
         incident_url: Optional[str] = None,
+        is_excluded: bool = False,
+        exclude_reason: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -295,6 +299,8 @@ class PolicyBreak(Base, FromDictMixin):
         self.known_secret = known_secret
         self.incident_url = incident_url
         self.matches = matches
+        self.is_excluded = is_excluded
+        self.exclude_reason = exclude_reason
 
     @property
     def is_secret(self) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,6 +112,34 @@ class TestModel:
                 },
             ),
             (
+                PolicyBreakSchema,
+                PolicyBreak,
+                {
+                    "type": "hello",
+                    "policy": "hello",
+                    "validity": "hey",
+                    "known_secret": True,
+                    "incident_url": "https://api.gitguardian.com/workspace/2/incidents/3",
+                    "matches": [{"match": "hello", "type": "hello"}],
+                    "is_excluded": True,
+                    "exclude_reason": "bad secret",
+                },
+            ),
+            (
+                PolicyBreakSchema,
+                PolicyBreak,
+                {
+                    "type": "hello",
+                    "policy": "hello",
+                    "validity": "hey",
+                    "known_secret": True,
+                    "incident_url": "https://api.gitguardian.com/workspace/2/incidents/3",
+                    "matches": [{"match": "hello", "type": "hello"}],
+                    "is_excluded": False,
+                    "exclude_reason": None,
+                },
+            ),
+            (
                 QuotaSchema,
                 Quota,
                 {


### PR DESCRIPTION
-  fix `load_default` for `incident_url`  (`None` instead of `False`)
- Handle two new fields in PolicyBreaks, that will be returned by the scan routes.

A bit bothered by using two fields, but using a single `exclude_reason` does not seem right either.