### PR TITLE
Add info as a possible value for Severity

### DIFF
--- a/changelog.d/20241107_113401_pierrelalanne_fix_typing_issue_on_severity.md
+++ b/changelog.d/20241107_113401_pierrelalanne_fix_typing_issue_on_severity.md
@@ -31,7 +31,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Add missing value "info" to Severity model.
+- Add missing value "info" to Severity model (#120).
 
 <!--
 ### Security

--- a/changelog.d/20241107_113401_pierrelalanne_fix_typing_issue_on_severity.md
+++ b/changelog.d/20241107_113401_pierrelalanne_fix_typing_issue_on_severity.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Add missing value "info" to Severity model.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -812,7 +812,7 @@ class Detector(Base, FromDictMixin):
     detector_group_display_name: str
 
 
-Severity = Literal["low", "medium", "high", "critical", "unknown"]
+Severity = Literal["info", "low", "medium", "high", "critical", "unknown"]
 ValidityStatus = Literal["valid", "invalid", "failed_to_check", "no_checker", "unknown"]
 IncidentStatus = Literal["IGNORED", "TRIGGERED", "RESOLVED", "ASSIGNED"]
 Tag = Literal[


### PR DESCRIPTION
This had been forgotten in the original implementation. See corresponding MR in ggshield to use this version of py-gitguardian until a new version is released.

This PR solves #120 