### PR TITLE
Pre-release renames

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -25,7 +25,7 @@ from .iac_models import (
     IaCScanResult,
 )
 from .models import (
-    ApiTokensResponse,
+    APITokensResponse,
     Detail,
     Document,
     DocumentSchema,
@@ -355,7 +355,7 @@ class GGClient:
 
     def api_tokens(
         self, token: Optional[str] = None
-    ) -> Union[Detail, ApiTokensResponse]:
+    ) -> Union[Detail, APITokensResponse]:
         """
         api_tokens retrieves details of an API token
         If no token is passed, the endpoint retrieves details for the current API token.
@@ -363,7 +363,7 @@ class GGClient:
         use Detail.status_code to check the response status code of the API
 
         200 if server is online, return token details
-        :return: Detail or ApiTokensReponse and status code
+        :return: Detail or APITokensReponse and status code
         """
         try:
             if not token:
@@ -376,7 +376,7 @@ class GGClient:
             result.status_code = 504
         else:
             if resp.ok:
-                result = ApiTokensResponse.from_dict(resp.json())
+                result = APITokensResponse.from_dict(resp.json())
             else:
                 result = load_detail(resp)
             result.status_code = resp.status_code

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -767,7 +767,7 @@ class TokenStatus(str, Enum):
     REVOKED = "revoked"
 
 
-class TokenScopes(str, Enum):
+class TokenScope(str, Enum):
     SCAN = "scan"
     INCIDENTS_READ = "incidents:read"
     INCIDENTS_WRITE = "incidents:write"
@@ -800,7 +800,7 @@ class ApiTokensResponseSchema(BaseSchema):
     revoked_at = fields.AwareDateTime(allow_none=True)
     member_id = fields.Int(allow_none=True)
     creator_id = fields.Int(allow_none=True)
-    scopes = fields.List(fields.Enum(TokenScopes, by_value=True), required=False)
+    scopes = fields.List(fields.Enum(TokenScope, by_value=True), required=False)
 
     @post_load
     def make_api_tokens_response(
@@ -825,7 +825,7 @@ class ApiTokensResponse(Base, FromDictMixin):
         revoked_at: Optional[datetime] = None,
         member_id: Optional[int] = None,
         creator_id: Optional[int] = None,
-        scopes: Optional[List[TokenScopes]] = None,
+        scopes: Optional[List[TokenScope]] = None,
     ):
         self.id = id
         self.name = name

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -788,7 +788,7 @@ class TokenScope(str, Enum):
     NHI_WRITE = "nhi:write"
 
 
-class ApiTokensResponseSchema(BaseSchema):
+class APITokensResponseSchema(BaseSchema):
     id = fields.UUID(required=True)
     name = fields.String(required=True)
     workspace_id = fields.Int(required=True)
@@ -805,12 +805,12 @@ class ApiTokensResponseSchema(BaseSchema):
     @post_load
     def make_api_tokens_response(
         self, data: Dict[str, Any], **kwargs: Any
-    ) -> "ApiTokensResponse":
-        return ApiTokensResponse(**data)
+    ) -> "APITokensResponse":
+        return APITokensResponse(**data)
 
 
-class ApiTokensResponse(Base, FromDictMixin):
-    SCHEMA = ApiTokensResponseSchema()
+class APITokensResponse(Base, FromDictMixin):
+    SCHEMA = APITokensResponseSchema()
 
     def __init__(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ from pygitguardian.config import (
     MULTI_DOCUMENT_LIMIT,
 )
 from pygitguardian.models import (
-    ApiTokensResponse,
+    APITokensResponse,
     Detail,
     HoneytokenResponse,
     HoneytokenWithContextResponse,
@@ -899,7 +899,7 @@ def test_api_tokens(client: GGClient, token):
     result = client.api_tokens(token)
 
     assert mock_response.call_count == 1
-    assert isinstance(result, ApiTokensResponse)
+    assert isinstance(result, APITokensResponse)
 
 
 @responses.activate

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,8 +3,8 @@ from typing import OrderedDict
 import pytest
 
 from pygitguardian.models import (
-    ApiTokensResponse,
-    ApiTokensResponseSchema,
+    APITokensResponse,
+    APITokensResponseSchema,
     Detail,
     DetailSchema,
     Document,
@@ -66,8 +66,8 @@ class TestModel:
                 {"detail": "hello", "status_code": 200},
             ),
             (
-                ApiTokensResponseSchema,
-                ApiTokensResponse,
+                APITokensResponseSchema,
+                APITokensResponse,
                 {
                     "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
                     "name": "myTokenName",


### PR DESCRIPTION
While reviewing the ggshield PR to check for tokens I realized two naming inconsistencies were merged here. This PR fixes them before we release:

- TokenScopes -> TokenScope: because enum names should be singular
- ApiToken* -> APIToken*: because PEP 8 says so. Also, this is more consistent with other classes of the package (`JWTService`, `JWTResponse`...)