### PR TITLE
fix: Add missing scopes to TokenScope enum

### DIFF
--- a/changelog.d/20250425_135326_salome.voltz.md
+++ b/changelog.d/20250425_135326_salome.voltz.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Added missing scopes to the TokenScope Enum.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -749,7 +749,11 @@ class TokenScope(str, Enum):
     IP_ALLOWLIST_WRITE = "ip_allowlist:write"
     SOURCES_READ = "sources:read"
     SOURCES_WRITE = "sources:write"
-    NHI_WRITE = "nhi:write"
+    NHI_WRITE_VAULT = "nhi:write-vault"
+    NHI_SEND_INVENTORY = "nhi:send-inventory"
+    CUSTOM_TAGS_READ = "custom_tags:read"
+    CUSTOM_TAGS_WRITE = "custom_tags:write"
+    SECRET_READ = "secrets:read"
 
 
 class APITokensResponseSchema(BaseSchema):
@@ -764,7 +768,7 @@ class APITokensResponseSchema(BaseSchema):
     revoked_at = fields.AwareDateTime(allow_none=True)
     member_id = fields.Int(allow_none=True)
     creator_id = fields.Int(allow_none=True)
-    scopes = fields.List(fields.Enum(TokenScope, by_value=True), required=False)
+    scopes = fields.List(fields.String, required=False)
 
     @post_load
     def make_api_tokens_response(
@@ -789,7 +793,7 @@ class APITokensResponse(Base, FromDictMixin):
         revoked_at: Optional[datetime] = None,
         member_id: Optional[int] = None,
         creator_id: Optional[int] = None,
-        scopes: Optional[List[TokenScope]] = None,
+        scopes: Optional[List[str]] = None,
     ):
         self.id = id
         self.name = name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,7 +80,7 @@ class TestModel:
                     "revoked_at": "2023-05-27T12:40:55.662949Z",
                     "member_id": 22015,
                     "creator_id": 22015,
-                    "scopes": ["incidents:read", "scan"],
+                    "scopes": ["incidents:read", "scan", "unplanned:scope"],
                 },
             ),
             (MatchSchema, Match, {"match": "hello", "type": "hello"}),


### PR DESCRIPTION
This fixes a bug in ggshield. 

When trying to scan somthing with flag `--with-incident-details`, ggshield performs a call to `/api_tokens/{token}`. The response is deserialized using an enum for scopes. 

The enum was missing some recently added scope. Thus, `ggshield secret scan path FILE --with-incident-details` was crashing when called with a token having the new scopes : 

![image](https://github.com/user-attachments/assets/3b0888ec-f1d5-45ff-8ecc-b5a1456a3f52)

 