### PR TITLE
feat(byos): change public API field name

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -584,7 +584,7 @@ class GGClient:
             "source_uuid": source_uuid,
             "documents": [
                 {
-                    "document_identifier": document["filename"],
+                    "filename": document["filename"],
                     "document": document["document"],
                 }
                 for document in request_obj

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -667,7 +667,7 @@ def test_scan_and_create_incidents_payload_structure(client: GGClient):
         "documents": [
             {
                 "document": DOCUMENT,
-                "document_identifier": FILENAME,
+                "filename": FILENAME,
             }
         ],
         "source_uuid": source_uuid,


### PR DESCRIPTION
We changed the field name in the API from `document_identifier` to `filename` to better align with other API endpoints.

This is not a breaking change: the API does still support the old `document_identifier` name.