### PR TITLE
Add MCP models for Agentic AI

### DIFF
--- a/changelog.d/20260421_121207_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260421_121207_paul.petit.ext_HEAD.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- New endpoints `send_ai_discovery()` and `log_mcp_activity`, with associated models.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -20,6 +20,7 @@ from .config import (
     MAXIMUM_PAYLOAD_SIZE,
 )
 from .models import (
+    AIDiscovery,
     APITokensResponse,
     CreateInvitation,
     CreateInvitationParameters,
@@ -38,6 +39,8 @@ from .models import (
     InvitationParameters,
     JWTResponse,
     JWTService,
+    MCPActivityRequest,
+    MCPActivityResponse,
     Member,
     MembersParameters,
     MultiScanResult,
@@ -1193,3 +1196,43 @@ class GGClient:
 
         if not is_delete_ok(response):
             return load_detail(response)
+
+    def send_ai_discovery(
+        self,
+        ai_discovery: AIDiscovery,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Union[Detail, AIDiscovery]:
+        response = self.post(
+            endpoint="nhi/ai/discovery",
+            data=ai_discovery.to_dict(),
+            extra_headers=extra_headers,
+        )
+
+        obj: Union[Detail, AIDiscovery]
+        if is_ok(response):
+            obj = AIDiscovery.from_dict(response.json())
+        else:
+            obj = load_detail(response)
+
+        obj.status_code = response.status_code
+        return obj
+
+    def log_mcp_activity(
+        self,
+        activity: MCPActivityRequest,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Union[Detail, MCPActivityResponse]:
+        response = self.post(
+            endpoint="nhi/ai/mcp-activity",
+            data=activity.to_dict(),
+            extra_headers=extra_headers,
+        )
+
+        obj: Union[Detail, MCPActivityResponse]
+        if is_ok(response):
+            obj = MCPActivityResponse.from_dict(response.json())
+        else:
+            obj = load_detail(response)
+
+        obj.status_code = response.status_code
+        return obj

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1576,3 +1576,262 @@ class CreateInvitationSchema(BaseSchema):
 
 
 CreateInvitation.SCHEMA = CreateInvitationSchema()
+
+
+@dataclass
+class MCPArgumentInfo(FromDictMixin, ToDictMixin):
+    name: str
+    type: str
+    description: Optional[str] = None
+    required: bool = False
+
+
+class MCPArgumentInfoSchema(BaseSchema):
+    name = fields.Str(required=True)
+    type = fields.Str(required=True)
+    description = fields.Str(load_default=None, dump_default=None)
+    required = fields.Bool(load_default=False, dump_default=False)
+
+    @post_load
+    def make_mcp_argument_info(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPArgumentInfo(**data)
+
+
+MCPArgumentInfo.SCHEMA = MCPArgumentInfoSchema()
+
+
+@dataclass
+class MCPToolInfo(FromDictMixin, ToDictMixin):
+    name: str
+    description: Optional[str] = None
+    arguments: Optional[List[MCPArgumentInfo]] = None
+
+
+class MCPToolInfoSchema(BaseSchema):
+    name = fields.Str(required=True)
+    description = fields.Str(load_default=None, dump_default=None)
+    arguments = fields.List(
+        fields.Nested(MCPArgumentInfoSchema), load_default=None, dump_default=None
+    )
+
+    @post_load
+    def make_mcp_tool_info(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPToolInfo(**data)
+
+
+MCPToolInfo.SCHEMA = MCPToolInfoSchema()
+
+
+@dataclass
+class MCPResourceInfo(FromDictMixin, ToDictMixin):
+    uri: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    mime_type: Optional[str] = None
+
+
+class MCPResourceInfoSchema(BaseSchema):
+    uri = fields.Str(required=True)
+    name = fields.Str(load_default=None, dump_default=None)
+    description = fields.Str(load_default=None, dump_default=None)
+    mime_type = fields.Str(load_default=None, dump_default=None)
+
+    @post_load
+    def make_mcp_resource_info(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPResourceInfo(**data)
+
+
+MCPResourceInfo.SCHEMA = MCPResourceInfoSchema()
+
+
+@dataclass
+class MCPPromptInfo(FromDictMixin, ToDictMixin):
+    name: str
+    description: Optional[str] = None
+
+
+class MCPPromptInfoSchema(BaseSchema):
+    name = fields.Str(required=True)
+    description = fields.Str(load_default=None, dump_default=None)
+
+    @post_load
+    def make_mcp_prompt_info(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPPromptInfo(**data)
+
+
+MCPPromptInfo.SCHEMA = MCPPromptInfoSchema()
+
+
+@dataclass
+class MCPConfiguration(FromDictMixin, ToDictMixin):
+    class Transport(str, Enum):
+        STDIO = "stdio"
+        HTTP = "http"
+        SSE = "sse"
+
+    class Scope(str, Enum):
+        USER = "user"
+        PROJECT = "project"
+
+    name: str
+    agent: str
+    scope: Scope
+    transport: Transport
+    project: Optional[str] = None
+    # stdio fields
+    command: Optional[str] = None
+    args: List[str] = field(default_factory=list)
+    env: Dict[str, str] = field(default_factory=dict)
+    # remote fields
+    url: Optional[str] = None
+    headers: Dict[str, str] = field(default_factory=dict)
+
+
+class MCPConfigurationSchema(BaseSchema):
+    name = fields.Str(required=True)
+    agent = fields.Str(required=True)
+    scope = fields.Enum(MCPConfiguration.Scope, by_value=True, required=True)
+    transport = fields.Enum(MCPConfiguration.Transport, by_value=True, required=True)
+    project = fields.Str(load_default=None, dump_default=None)
+    command = fields.Str(load_default=None, dump_default=None)
+    args = fields.List(fields.Str(), load_default=[], dump_default=[])
+    env = fields.Dict(
+        keys=fields.Str(), values=fields.Str(), load_default={}, dump_default={}
+    )
+    url = fields.Str(load_default=None, dump_default=None)
+    headers = fields.Dict(
+        keys=fields.Str(), values=fields.Str(), load_default={}, dump_default={}
+    )
+
+    @post_load
+    def make_mcp_configuration(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPConfiguration(**data)
+
+
+MCPConfiguration.SCHEMA = MCPConfigurationSchema()
+
+
+@dataclass
+class MCPServer(FromDictMixin, ToDictMixin):
+    name: str
+    # We don't expect display_name to be set by ggshield, it will be set by us
+    # and sent back to ggshield.
+    display_name: Optional[str] = None
+    tools: List[MCPToolInfo] = field(default_factory=list)
+    resources: List[MCPResourceInfo] = field(default_factory=list)
+    prompts: List[MCPPromptInfo] = field(default_factory=list)
+    configurations: List[MCPConfiguration] = field(default_factory=list)
+
+
+class MCPServerSchema(BaseSchema):
+    name = fields.Str(required=True)
+    display_name = fields.Str(load_default=None, dump_default=None)
+    tools = fields.List(
+        fields.Nested(MCPToolInfoSchema), load_default=[], dump_default=[]
+    )
+    resources = fields.List(
+        fields.Nested(MCPResourceInfoSchema), load_default=[], dump_default=[]
+    )
+    prompts = fields.List(
+        fields.Nested(MCPPromptInfoSchema), load_default=[], dump_default=[]
+    )
+    configurations = fields.List(
+        fields.Nested(MCPConfigurationSchema), load_default=[], dump_default=[]
+    )
+
+    @post_load
+    def make_mcp_server(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPServer(**data)
+
+
+MCPServer.SCHEMA = MCPServerSchema()
+
+
+@dataclass
+class UserInfo(FromDictMixin, ToDictMixin):
+    hostname: str
+    username: str
+    machine_id: str
+    user_email: Optional[str] = None
+
+
+class UserInfoSchema(BaseSchema):
+    hostname = fields.Str(required=True)
+    username = fields.Str(required=True)
+    machine_id = fields.Str(required=True)
+    user_email = fields.Str(load_default=None, dump_default=None)
+
+    @post_load
+    def make_user_info(self, data: Dict[str, Any], **kwargs: Any):
+        return UserInfo(**data)
+
+
+UserInfo.SCHEMA = UserInfoSchema()
+
+
+@dataclass
+class AIDiscovery(FromDictWithBase):
+    user: UserInfo
+    discovery_duration: float  # in seconds
+    servers: List[MCPServer] = field(default_factory=list)
+
+
+class AIDiscoverySchema(BaseSchema):
+    user = fields.Nested(UserInfoSchema, required=True)
+    discovery_duration = fields.Float(required=True)
+    servers = fields.List(
+        fields.Nested(MCPServerSchema), load_default=[], dump_default=[]
+    )
+
+    @post_load
+    def make_ai_discovery(self, data: Dict[str, Any], **kwargs: Any):
+        return AIDiscovery(**data)
+
+
+AIDiscovery.SCHEMA = AIDiscoverySchema()
+
+
+@dataclass
+class MCPActivityRequest(FromDictMixin, ToDictMixin):
+    user: UserInfo
+    tool: str
+    server: str
+    agent: str
+    model: str
+    cwd: str
+    input: Dict[str, Any]
+
+
+class MCPActivityRequestSchema(BaseSchema):
+    user = fields.Nested(UserInfoSchema, required=True)
+    tool = fields.Str(required=True)
+    server = fields.Str(required=True)
+    agent = fields.Str(required=True)
+    model = fields.Str(required=True)
+    cwd = fields.Str(required=True)
+    input = fields.Dict(keys=fields.Str(), values=fields.Raw(), required=True)
+
+    @post_load
+    def make_mcp_activity_request(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPActivityRequest(**data)
+
+
+MCPActivityRequest.SCHEMA = MCPActivityRequestSchema()
+
+
+@dataclass
+class MCPActivityResponse(FromDictWithBase):
+    allowed: bool
+    reason: str
+
+
+class MCPActivityResponseSchema(BaseSchema):
+    allowed = fields.Bool(required=True)
+    reason = fields.Str(required=True)
+
+    @post_load
+    def make_mcp_activity_response(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPActivityResponse(**data)
+
+
+MCPActivityResponse.SCHEMA = MCPActivityResponseSchema()

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1478,7 +1478,6 @@ class TeamSourceParameters(PaginationParameter, SearchParameter, ToDictMixin):
     last_scan_status: Optional[ScanStatus] = None
     type: Optional[str] = None
     health: Optional[SourceHealth] = None
-    type: Optional[str] = None
     ordering: Optional[Literal["last_scan_date", "-last_scan_date"]] = None
     visibility: Optional[str] = None
     external_id: Optional[str] = None

--- a/tests/cassettes/test_log_mcp_activity.yaml
+++ b/tests/cassettes/test_log_mcp_activity.yaml
@@ -1,0 +1,61 @@
+interactions:
+  - request:
+      body: '{"user": {"hostname": "toto-laptop", "username": "toto", "machine_id":
+        "1234567890", "user_email": "toto@gitguardian.com"}, "tool": "toto", "server":
+        "https://mcp-server-1.com", "agent": "cursor", "model": "composer-2", "cwd":
+        "/home/user/project", "input": {"foo": "bar"}}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '273'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.29.0 (Linux;py3.11.15)
+      method: POST
+      uri: https://api.gitguardian.com/v1/nhi/ai/mcp-activity
+    response:
+      body:
+        string: '{"allowed":true,"reason":""}'
+      headers:
+        Access-Control-Expose-Headers:
+          - X-App-Version
+        Allow:
+          - POST, OPTIONS
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '28'
+        Content-Security-Policy:
+          - frame-ancestors 'none'
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Date:
+          - Tue, 21 Apr 2026 09:57:44 GMT
+        Referrer-Policy:
+          - same-origin
+        Server:
+          - nginx/1.29.1
+        Vary:
+          - Cookie
+        X-App-Version:
+          - dev
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+        X-Request-ID:
+          - 0b5ebf3512d3af02d66646406b48180d
+        X-Secrets-Engine-Version:
+          - 2.161.0
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/cassettes/test_send_ai_discovery.yaml
+++ b/tests/cassettes/test_send_ai_discovery.yaml
@@ -1,0 +1,63 @@
+interactions:
+  - request:
+      body: '{"user": {"hostname": "toto-laptop", "username": "toto", "machine_id":
+        "1234567890", "user_email": "toto@gitguardian.com"}, "discovery_duration": 0.5,
+        "servers": [{"name": "mcp-server-1", "display_name": null, "tools": [], "resources":
+        [], "prompts": [], "configurations": [{"name": "mcp-configuration-1", "agent":
+        "cursor", "scope": "user", "transport": "http", "project": null, "command":
+        null, "args": [], "env": {}, "url": "https://mcp-server-1.com", "headers": {}}]}]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '473'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.29.0 (Linux;py3.11.15)
+      method: POST
+      uri: https://api.gitguardian.com/v1/nhi/ai/discovery
+    response:
+      body:
+        string: '{"user":{"hostname":"toto-laptop","username":"toto","machine_id":"1234567890","user_email":"toto@gitguardian.com"},"servers":[{"name":"https://mcp-server-1.com","display_name":"","tools":[],"resources":[],"prompts":[],"configurations":[{"name":"mcp-configuration-1","agent":"cursor","scope":"user","transport":"http","project":null,"command":null,"args":[],"env":{},"url":"https://mcp-server-1.com","headers":{}}]}],"discovery_duration":0.5}'
+      headers:
+        Access-Control-Expose-Headers:
+          - X-App-Version
+        Allow:
+          - POST, OPTIONS
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '441'
+        Content-Security-Policy:
+          - frame-ancestors 'none'
+        Content-Type:
+          - application/json
+        Cross-Origin-Opener-Policy:
+          - same-origin
+        Date:
+          - Tue, 21 Apr 2026 09:57:44 GMT
+        Referrer-Policy:
+          - same-origin
+        Server:
+          - nginx/1.29.1
+        Vary:
+          - Cookie
+        X-App-Version:
+          - dev
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+        X-Request-ID:
+          - fb763215b6af5bfa3f5d34e7c26cd9dc
+        X-Secrets-Engine-Version:
+          - 2.161.0
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,6 +25,7 @@ from pygitguardian.config import (
 )
 from pygitguardian.models import (
     AccessLevel,
+    AIDiscovery,
     APITokensResponse,
     CreateInvitation,
     CreateInvitationParameters,
@@ -41,6 +42,10 @@ from pygitguardian.models import (
     Invitation,
     JWTResponse,
     JWTService,
+    MCPActivityRequest,
+    MCPActivityResponse,
+    MCPConfiguration,
+    MCPServer,
     Member,
     MembersParameters,
     MultiScanResult,
@@ -58,6 +63,7 @@ from pygitguardian.models import (
     UpdateMember,
     UpdateTeam,
     UpdateTeamSource,
+    UserInfo,
 )
 from pygitguardian.models_utils import CursorPaginatedResponse
 
@@ -1858,3 +1864,68 @@ def test_delete_invitation(client: GGClient):
     result = client.delete_invitation(invitations.data[0].id)
 
     assert result is None
+
+
+@my_vcr.use_cassette("test_send_ai_discovery.yaml", ignore_localhost=False)
+def test_send_ai_discovery(client: GGClient):
+    """
+    GIVEN a client
+    WHEN calling POST /nhi/ai/discovery endpoint
+    THEN an AI discovery is sent
+    """
+
+    result = client.send_ai_discovery(
+        AIDiscovery(
+            user=UserInfo(
+                user_email="toto@gitguardian.com",
+                hostname="toto-laptop",
+                username="toto",
+                machine_id="1234567890",
+            ),
+            discovery_duration=0.5,
+            servers=[
+                MCPServer(
+                    name="mcp-server-1",
+                    configurations=[
+                        MCPConfiguration(
+                            name="mcp-configuration-1",
+                            agent="cursor",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.HTTP,
+                            url="https://mcp-server-1.com",
+                        )
+                    ],
+                )
+            ],
+        )
+    )
+
+    assert isinstance(result, AIDiscovery), result
+
+
+@my_vcr.use_cassette("test_log_mcp_activity.yaml", ignore_localhost=False)
+def test_log_mcp_activity(client: GGClient):
+    """
+    GIVEN a client
+    WHEN calling POST /nhi/ai/mcp-activity endpoint
+    THEN an MCP activity is logged
+    """
+
+    result = client.log_mcp_activity(
+        MCPActivityRequest(
+            user=UserInfo(
+                user_email="toto@gitguardian.com",
+                hostname="toto-laptop",
+                username="toto",
+                machine_id="1234567890",
+            ),
+            tool="toto",
+            server="https://mcp-server-1.com",
+            agent="cursor",
+            model="composer-2",
+            cwd="/home/user/project",
+            input={"foo": "bar"},
+        )
+    )
+
+    assert isinstance(result, MCPActivityResponse), result

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,8 @@ from typing import OrderedDict
 import pytest
 
 from pygitguardian.models import (
+    AIDiscovery,
+    AIDiscoverySchema,
     APITokensResponse,
     APITokensResponseSchema,
     Detail,
@@ -16,6 +18,10 @@ from pygitguardian.models import (
     HoneytokenWithContextResponseSchema,
     Match,
     MatchSchema,
+    MCPActivityRequest,
+    MCPActivityRequestSchema,
+    MCPActivityResponse,
+    MCPActivityResponseSchema,
     MultiScanResult,
     MultiScanResultSchema,
     PolicyBreak,
@@ -471,6 +477,55 @@ class TestModel:
                         "url": "https://github.com/GitGuardian/py-gitguardian",
                     },
                     "tags": ["FROM_HISTORICAL_SCAN"],
+                },
+            ),
+            (
+                AIDiscoverySchema,
+                AIDiscovery,
+                {
+                    "user": {
+                        "user_email": "toto@gitguardian.com",
+                        "hostname": "toto-laptop",
+                        "username": "toto",
+                        "machine_id": "1234567890",
+                    },
+                    "discovery_duration": 10.0,
+                    "servers": [
+                        {
+                            "name": "mcp-server",
+                            "url": "https://mcp-server.com",
+                        },
+                        {
+                            "name": "mcp-server",
+                            "url": "https://mcp-server.com",
+                        },
+                    ],
+                },
+            ),
+            (
+                MCPActivityRequestSchema,
+                MCPActivityRequest,
+                {
+                    "user": {
+                        "user_email": "toto@gitguardian.com",
+                        "machine_id": "1234567890",
+                        "hostname": "toto-laptop",
+                        "username": "toto",
+                    },
+                    "tool": "list-todos",
+                    "server": "https://mcp-server.com",
+                    "agent": "cursor",
+                    "model": "gpt-4o",
+                    "cwd": "/home/user/project",
+                    "input": {"key": "value"},
+                },
+            ),
+            (
+                MCPActivityResponseSchema,
+                MCPActivityResponse,
+                {
+                    "allowed": True,
+                    "reason": "test",
                 },
             ),
         ],


### PR DESCRIPTION
The first version of the Agentic AI feature (containing MCP server discovery and activity monitoring) has been merged in the platform and `ggshield` will soon be able to feed it data.

This PR adds the necessary model for the new endpoints.