### PR TITLE
feat: bulk mcp activity route

### DIFF
--- a/changelog.d/20260512_175247_paul.beslin-ext_bulk_mcp_activity.md
+++ b/changelog.d/20260512_175247_paul.beslin-ext_bulk_mcp_activity.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- New endpoint `log_mcp_activities_bulk()`: send a batch of historical `MCPActivityRequest` to GitGuardian and receive ingested/duplicate counts. Adds `MCPActivityBulkResponse` model.
+
+- Optional `timestamp` field on `MCPActivityRequest`, used by the bulk endpoint to record historical events. Live (single-event) `log_mcp_activity` callers are unaffected; the new field defaults to `None`.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -39,6 +39,7 @@ from .models import (
     InvitationParameters,
     JWTResponse,
     JWTService,
+    MCPActivityBulkResponse,
     MCPActivityRequest,
     MCPActivityResponse,
     Member,
@@ -1232,6 +1233,26 @@ class GGClient:
         obj: Union[Detail, MCPActivityResponse]
         if is_ok(response):
             obj = MCPActivityResponse.from_dict(response.json())
+        else:
+            obj = load_detail(response)
+
+        obj.status_code = response.status_code
+        return obj
+
+    def log_mcp_activities_bulk(
+        self,
+        activities: List[MCPActivityRequest],
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Union[Detail, MCPActivityBulkResponse]:
+        response = self.post(
+            endpoint="nhi/ai/mcp-activity/bulk",
+            data={"activities": [a.to_dict() for a in activities]},
+            extra_headers=extra_headers,
+        )
+
+        obj: Union[Detail, MCPActivityBulkResponse]
+        if is_ok(response):
+            obj = MCPActivityBulkResponse.from_dict(response.json())
         else:
             obj = load_detail(response)
 

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1815,6 +1815,7 @@ class MCPActivityRequest(FromDictMixin, ToDictMixin):
     model: str
     cwd: str
     input: Dict[str, Any]
+    timestamp: Optional[datetime] = None
 
 
 class MCPActivityRequestSchema(BaseSchema):
@@ -1825,6 +1826,7 @@ class MCPActivityRequestSchema(BaseSchema):
     model = fields.Str(required=True)
     cwd = fields.Str(required=True)
     input = fields.Dict(keys=fields.Str(), values=fields.Raw(), required=True)
+    timestamp = fields.DateTime(load_default=None, allow_none=True)
 
     @post_load
     def make_mcp_activity_request(self, data: Dict[str, Any], **kwargs: Any):
@@ -1850,3 +1852,23 @@ class MCPActivityResponseSchema(BaseSchema):
 
 
 MCPActivityResponse.SCHEMA = MCPActivityResponseSchema()
+
+
+@dataclass
+class MCPActivityBulkResponse(FromDictWithBase):
+    ingested: int
+    duplicates: int
+    skipped: int
+
+
+class MCPActivityBulkResponseSchema(BaseSchema):
+    ingested = fields.Int(required=True)
+    duplicates = fields.Int(required=True)
+    skipped = fields.Int(required=True)
+
+    @post_load
+    def make_mcp_activity_bulk_response(self, data: Dict[str, Any], **kwargs: Any):
+        return MCPActivityBulkResponse(**data)
+
+
+MCPActivityBulkResponse.SCHEMA = MCPActivityBulkResponseSchema()

--- a/tests/cassettes/test_log_mcp_activities_bulk_posts_to_correct_endpoint.yaml
+++ b/tests/cassettes/test_log_mcp_activities_bulk_posts_to_correct_endpoint.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: '{"activities": [{"user": {"hostname": "h", "username": "u", "machine_id":
+        "m", "user_email": null}, "tool": "t", "server": "s", "agent": "claude-code",
+        "model": "m", "cwd": "/tmp", "input": {}, "timestamp": "2026-04-01T09:00:00+00:00"},
+        {"user": {"hostname": "h", "username": "u", "machine_id": "m", "user_email":
+        null}, "tool": "t", "server": "s", "agent": "claude-code", "model": "m",
+        "cwd": "/tmp", "input": {}, "timestamp": "2026-04-01T09:00:00+00:00"}]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '458'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.30.0 (Linux;py3.11.15)
+      method: POST
+      uri: https://api.gitguardian.com/v1/nhi/ai/mcp-activity/bulk
+    response:
+      body:
+        string: '{"ingested": 2, "duplicates": 0, "skipped": 0}'
+      headers:
+        Allow:
+          - POST, OPTIONS
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '46'
+        Content-Type:
+          - application/json
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import os
 import re
 import tarfile
 from collections import OrderedDict
-from datetime import date
+from datetime import date, datetime, timezone
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Type
 from unittest.mock import Mock, patch
@@ -42,6 +42,7 @@ from pygitguardian.models import (
     Invitation,
     JWTResponse,
     JWTService,
+    MCPActivityBulkResponse,
     MCPActivityRequest,
     MCPActivityResponse,
     MCPConfiguration,
@@ -1970,3 +1971,47 @@ def test_log_mcp_activity(client: GGClient):
     )
 
     assert isinstance(result, MCPActivityResponse), result
+
+
+@my_vcr.use_cassette(
+    "test_log_mcp_activities_bulk_posts_to_correct_endpoint.yaml",
+    ignore_localhost=False,
+)
+def test_log_mcp_activities_bulk_posts_to_correct_endpoint(
+    client: GGClient,
+):
+    """
+    GIVEN a ggclient
+    WHEN calling log_mcp_activities_bulk with a list of MCPActivityRequest
+    THEN a POST is made to the bulk endpoint
+    AND an MCPActivityBulkResponse is returned with ingested/duplicate counts
+    """
+    activities = [
+        MCPActivityRequest(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            tool="t",
+            server="s",
+            agent="claude-code",
+            model="m",
+            cwd="/tmp",
+            input={},
+            timestamp=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+        ),
+        MCPActivityRequest(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            tool="t",
+            server="s",
+            agent="claude-code",
+            model="m",
+            cwd="/tmp",
+            input={},
+            timestamp=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+        ),
+    ]
+
+    result = client.log_mcp_activities_bulk(activities)
+
+    assert isinstance(result, MCPActivityBulkResponse)
+    assert result.ingested == 2
+    assert result.duplicates == 0
+    assert result.skipped == 0


### PR DESCRIPTION
This PR prepares the MCP activity history scan for GGShield.

- New GitGuardian API route to send batches of `MCPActivityRequest`
- Added one new optional field to `MCPActivityRequest`, extracted from the agent history files:  
  - `timestamp`: time at which the MCP call was made (was always considered to be `now` for live MCP calls)

An idempotency key is computed on GitGuardian API.

:warning: The GitGuardian API route doesn't exist yet, and is required for this to be merged.