### PR TITLE
chore(pre-commit): update to ggshield 1.51.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.50.3
+    rev: v1.51.0
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
Bumps the ggshield pre-commit hook to v1.51.0.

Part of the [END-184 release checklist](https://linear.app/gitguardian/issue/END-184/release-ggshield) for ggshield 1.51.0.

Release notes: https://github.com/GitGuardian/ggshield/releases/tag/v1.51.0