### PR TITLE
test(client): make bulk mcp activity test time-independent

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,9 @@ import json
 import os
 import re
 import tarfile
+import uuid
 from collections import OrderedDict
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Type
 from unittest.mock import Mock, patch
@@ -1986,27 +1987,24 @@ def test_log_mcp_activities_bulk_posts_to_correct_endpoint(
     THEN a POST is made to the bulk endpoint
     AND an MCPActivityBulkResponse is returned with ingested/duplicate counts
     """
+    # Fresh, per-run-unique events so the cassette-less release run
+    # (`scripts/release run-tests`) always ingests them: a stale timestamp is
+    # rejected by the backfill window and repeated events are deduplicated.
+    # Cassette replay matches on method+url (see conftest.my_vcr), so the
+    # request body here does not affect recorded-cassette runs.
+    recent = datetime.now(timezone.utc) - timedelta(hours=1)
     activities = [
         MCPActivityRequest(
-            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            user=UserInfo(hostname="h", username="u", machine_id=uuid.uuid4().hex),
             tool="t",
             server="s",
             agent="claude-code",
             model="m",
             cwd="/tmp",
             input={},
-            timestamp=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
-        ),
-        MCPActivityRequest(
-            user=UserInfo(hostname="h", username="u", machine_id="m"),
-            tool="t",
-            server="s",
-            agent="claude-code",
-            model="m",
-            cwd="/tmp",
-            input={},
-            timestamp=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
-        ),
+            timestamp=recent,
+        )
+        for _ in range(2)
     ]
 
     result = client.log_mcp_activities_bulk(activities)


### PR DESCRIPTION
## What

Make `test_log_mcp_activities_bulk_posts_to_correct_endpoint` time-independent so the cassette-less release run (`scripts/release run-tests`) passes reliably regardless of the calendar date.

## Why

During the **1.31.0** release, `scripts/release run-tests` (runs the suite **without cassettes**, against the real prod API) failed only this test:

```
MCPActivityBulkResponse(ingested=0, duplicates=0, skipped=2)  # asserted ingested == 2
```

The test posted two identical `MCPActivityRequest` payloads with a hardcoded `timestamp=2026-04-01T09:00:00Z`. By release time prod **skipped** them — the timestamp had aged out of the bulk backfill window and/or those exact idempotent events were already ingested when the cassette was first recorded. Endpoint returns HTTP 200 and deserializes correctly, so this is **not a code regression** — just a stale, calendar-pinned fixture.

## Fix

Use a **recent timestamp** (1h ago) and a **unique `machine_id` per event** (`uuid4`) so prod always ingests two fresh events. No client/product code change.

## Why no cassette re-record

`conftest.my_vcr` uses `match_on=["method", "url"]` (not body) with `record_mode="once"`, so the committed cassette replays purely on URL and its response (`ingested: 2`) is already correct. A runtime-varying body can never "match" a stored body anyway, so re-recording adds no value. Cassette-based CI stays green; verified locally:

```
pytest tests/test_client.py -k mcp_activit  →  2 passed
black --check / pyflakes  →  clean
```

Closes END-536.
Follow-up from the 1.31.0 release (END-376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)