### PR TITLE
feat: support marshmallow 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ with all the response codes and expected structures on each method.
 
 Python 3.8+
 
+> [!WARNING]
+> Python 3.8 support is deprecated and will be removed in a future release.
+> On Python 3.8, `marshmallow` 3.x is used; Python 3.9+ uses `marshmallow` 4.x.
+
 ## Projects using `py-gitguardian`
 
 - [**GitGuardian Shield**](https://github.com/GitGuardian/gg-shield) - Scan for secrets in your CI and pre-commit.

--- a/changelog.d/20260616_085944_benjamin.rigaud_marshmallow_4.md
+++ b/changelog.d/20260616_085944_benjamin.rigaud_marshmallow_4.md
@@ -1,3 +1,7 @@
 ### Changed
 
 - The library is now compatible with marshmallow 4 (`marshmallow>=3.18, <5`). On Python 3.9+ marshmallow 4 is used; Python 3.8 keeps marshmallow 3. As a result, `to_dict()` and `from_dict()` now return a plain `dict` instead of an `OrderedDict` (insertion order is still preserved). `marshmallow-dataclass` is bumped to `>=8.7, <8.8`.
+
+### Deprecated
+
+- Python 3.8 support is deprecated and will be removed in a future release. Importing the library on Python 3.8 now emits a `DeprecationWarning`. Upgrade to Python 3.9+.

--- a/changelog.d/20260616_085944_benjamin.rigaud_marshmallow_4.md
+++ b/changelog.d/20260616_085944_benjamin.rigaud_marshmallow_4.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The library is now compatible with marshmallow 4 (`marshmallow>=3.18, <5`). On Python 3.9+ marshmallow 4 is used; Python 3.8 keeps marshmallow 3. As a result, `to_dict()` and `from_dict()` now return a plain `dict` instead of an `OrderedDict` (insertion order is still preserved). `marshmallow-dataclass` is bumped to `>=8.7, <8.8`.

--- a/pygitguardian/__init__.py
+++ b/pygitguardian/__init__.py
@@ -1,6 +1,18 @@
 """PyGitGuardian API Client"""
 
+import sys
+import warnings
+
 from .client import ContentTooLarge, GGClient, GGClientCallbacks
+
+
+if sys.version_info < (3, 9):
+    warnings.warn(
+        "Python 3.8 support is deprecated and will be removed in a future "
+        "py-gitguardian release; upgrade to Python 3.9+.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 __version__ = "1.31.0"

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -573,7 +573,7 @@ class HoneytokenResponseSchema(BaseSchema):
     revoker_id = fields.Int(allow_none=True)
     creator_api_token_id = fields.String(allow_none=True)
     revoker_api_token_id = fields.String(allow_none=True)
-    token = fields.Mapping(fields.String(), fields.String())
+    token = fields.Dict(keys=fields.String(), values=fields.String())
     tags = fields.List(fields.String())
 
     @post_load

--- a/pygitguardian/models_utils.py
+++ b/pygitguardian/models_utils.py
@@ -56,7 +56,6 @@ class FromDictMixin:
 
 class BaseSchema(Schema):
     class Meta:
-        ordered = True
         unknown = EXCLUDE
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ classifiers = [
 license = {text = "MIT"}
 requires-python = ">=3.8"
 dependencies = [
-    "marshmallow>=3.5, <4",
+    "marshmallow>=3.18, <5",
     "requests>=2, <3",
-    "marshmallow-dataclass >=8.5.8, <8.6.0",
+    "marshmallow-dataclass >=8.7, <8.8",
     "typing-extensions",
     "setuptools>=70.1.0",
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,6 @@ import os
 import re
 import tarfile
 import uuid
-from collections import OrderedDict
 from datetime import date, datetime, timedelta, timezone
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -272,7 +271,7 @@ def test_health_check(client: GGClient):
     assert bool(health)
     assert health.success
 
-    assert type(health.to_dict()) == OrderedDict
+    assert type(health.to_dict()) == dict
     assert type(health.to_json()) == str
 
 
@@ -314,7 +313,7 @@ def test_multi_content_scan(
     assert multiscan.status_code == 200
     assert isinstance(multiscan, MultiScanResult)
 
-    assert type(multiscan.to_dict()) == OrderedDict
+    assert type(multiscan.to_dict()) == dict
     assert type(multiscan.to_json()) == str
     assert type(repr(multiscan)) == str
     assert type(str(multiscan)) == str
@@ -444,7 +443,7 @@ def test_content_scan(
         else:
             pytest.fail("returned should be a ScanResult")
 
-        assert isinstance(scan_result.to_dict(), OrderedDict)
+        assert isinstance(scan_result.to_dict(), dict)
         scan_result_json = scan_result.to_json()
         assert isinstance(scan_result_json, str)
         assert isinstance(json.loads(scan_result_json), dict)
@@ -940,7 +939,7 @@ def test_quota_overview(client: GGClient):
         else:
             pytest.fail("returned should be a QuotaResponse")
 
-        assert isinstance(quota_response.to_dict(), OrderedDict)
+        assert isinstance(quota_response.to_dict(), dict)
         quota_response_json = quota_response.to_json()
         assert isinstance(quota_response_json, str)
         assert isinstance(json.loads(quota_response_json), dict)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,3 @@
-from typing import OrderedDict
-
 import pytest
 
 from pygitguardian.models import (
@@ -65,10 +63,10 @@ class TestModel:
     @pytest.mark.parametrize(
         "schema_klass, expected_klass, instance_data",
         [
-            (DocumentSchema, OrderedDict, {"filename": "hello", "document": "hello"}),
+            (DocumentSchema, dict, {"filename": "hello", "document": "hello"}),
             (
                 HealthCheckResponseSchema,
-                OrderedDict,
+                dict,
                 {"detail": "hello", "status_code": 200},
             ),
             (


### PR DESCRIPTION
## Summary

marshmallow 3.x is no longer maintained, and downstream packagers (NixOS) have moved to marshmallow 4, which made `py-gitguardian` uninstallable there (see #167 and [NixOS/nixpkgs#483266](https://github.com/NixOS/nixpkgs/issues/483266)).

Rather than dropping Python 3.8 outright, this widens the dependency range so the package supports **both** marshmallow majors:

- `marshmallow>=3.18, <5` and `marshmallow-dataclass>=8.7, <8.8`
- Python **3.8 keeps marshmallow 3.26**; Python **3.9+ resolves to marshmallow 4** (which requires ≥3.9). This unblocks modern environments like NixOS while leaving 3.8 support intact for now.

### Changes for v4 compatibility
- `fields.Mapping` is abstract in marshmallow 4 → use `fields.Dict(keys=…, values=…)`.
- Drop the now-removed `Meta.ordered` on `BaseSchema`. `to_dict()`/`from_dict()` now return a plain `dict` (insertion order still preserved) instead of an `OrderedDict`; affected test assertions updated.
- Changelog fragment added.

## Test plan
- [x] Full suite green under **marshmallow 4.3.0** (120 passed)
- [x] Full suite green under **marshmallow 3.26.2** (120 passed) — the Python 3.8 resolution path
- [x] `black`, `isort`, `flake8` clean; `pyright` 0 errors
- [ ] CI matrix (3.8–3.12 × {ubuntu, macos, windows}) green

Linear: END-538
Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)