### PR TITLE
chore(pre-commit): update to ggshield 1.52.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.51.0
+    rev: v1.52.0
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
Bump the `ggshield` pre-commit hook to the freshly released `v1.52.0` (release END-375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)