### PR TITLE
fix(client): correct agent activity endpoint path

### DIFF
--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -1282,7 +1282,7 @@ class GGClient:
         data: Dict[str, Any] = {"events": events}
         data["user"] = user.to_dict()
         response = self.post(
-            endpoint="nhi/ai/activity",
+            endpoint="agent-activity/activity",
             data=data,
             extra_headers=extra_headers,
         )

--- a/tests/cassettes/test_send_agent_activity_posts_to_correct_endpoint.yaml
+++ b/tests/cassettes/test_send_agent_activity_posts_to_correct_endpoint.yaml
@@ -18,7 +18,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.30.0 (Linux;py3.11.15)
       method: POST
-      uri: https://api.gitguardian.com/v1/nhi/ai/activity
+      uri: https://api.gitguardian.com/v1/agent-activity/activity
     response:
       body:
         string: '{"ingested": 2, "dropped": 0}'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2090,7 +2090,7 @@ def test_send_agent_activity_includes_user_in_payload(client: GGClient):
     with patch.object(client, "post", side_effect=_fake_post):
         result = client.send_agent_activity(events, user=user)
 
-    assert captured["endpoint"] == "nhi/ai/activity"
+    assert captured["endpoint"] == "agent-activity/activity"
     assert captured["data"]["user"] == user.to_dict()
     assert captured["data"]["events"] == events
     assert isinstance(result, AgentActivityResponse)


### PR DESCRIPTION
## What

Correct the endpoint path used by `GGClient.send_agent_activity` from `nhi/ai/activity` to `agent-activity/activity`.

## Why

The endpoint introduced in #175 used the wrong path. This corrects it to the actual API route. Since the original endpoint was added after the latest release (1.32.0) and never shipped, this is a fix for an unreleased regression — hence `skip-changelog`.

## Changes

- `pygitguardian/client.py`: update endpoint string
- `tests/test_client.py` + cassette: update expectations to match the corrected endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)