### PR TITLE
chore(pre-commit): update to ggshield 1.52.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.52.1
+    rev: v1.52.2
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
Post-release fan-out for ggshield 1.52.2 (END-560): bump the ggshield pre-commit hook to `v1.52.2`.