### PR TITLE
Add hooks installation status

### DIFF
--- a/changelog.d/20260618_155738_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260618_155738_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Added
+
+- AI discovery now also sends whether hooks are globally installed, per agent.

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1786,10 +1786,32 @@ UserInfo.SCHEMA = UserInfoSchema()
 
 
 @dataclass
+class AgentInfo(FromDictMixin, ToDictMixin):
+    name: str
+    # Whether the ggshield AI hooks are installed for this agent (globally).
+    hooks_installed: bool
+    hooks_command: Optional[str] = None
+
+
+class AgentInfoSchema(BaseSchema):
+    name = fields.Str(required=True)
+    hooks_installed = fields.Bool(required=True)
+    hooks_command = fields.Str(load_default=None, dump_default=None)
+
+    @post_load
+    def make_agent_info(self, data: Dict[str, Any], **kwargs: Any):
+        return AgentInfo(**data)
+
+
+AgentInfo.SCHEMA = AgentInfoSchema()
+
+
+@dataclass
 class AIDiscovery(FromDictWithBase):
     user: UserInfo
     discovery_duration: float  # in seconds
     servers: List[MCPServer] = field(default_factory=list)
+    agents: List[AgentInfo] = field(default_factory=list)
 
 
 class AIDiscoverySchema(BaseSchema):
@@ -1797,6 +1819,9 @@ class AIDiscoverySchema(BaseSchema):
     discovery_duration = fields.Float(required=True)
     servers = fields.List(
         fields.Nested(MCPServerSchema), load_default=[], dump_default=[]
+    )
+    agents = fields.List(
+        fields.Nested(AgentInfoSchema), load_default=[], dump_default=[]
     )
 
     @post_load

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,6 +26,7 @@ from pygitguardian.config import (
 from pygitguardian.models import (
     AccessLevel,
     AgentActivityResponse,
+    AgentInfo,
     AIDiscovery,
     APITokensResponse,
     CreateInvitation,
@@ -1938,6 +1939,13 @@ def test_send_ai_discovery(client: GGClient):
                             url="https://mcp-server-1.com",
                         )
                     ],
+                )
+            ],
+            agents=[
+                AgentInfo(
+                    name="cursor",
+                    hooks_installed=True,
+                    hooks_command="ggshield hooks install cursor",
                 )
             ],
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,8 @@ import pytest
 from pygitguardian.models import (
     AgentActivityResponse,
     AgentActivityResponseSchema,
+    AgentInfo,
+    AgentInfoSchema,
     AIDiscovery,
     AIDiscoverySchema,
     APITokensResponse,
@@ -480,6 +482,23 @@ class TestModel:
                 },
             ),
             (
+                AgentInfoSchema,
+                AgentInfo,
+                {
+                    "name": "cursor",
+                    "hooks_installed": True,
+                },
+            ),
+            (
+                AgentInfoSchema,
+                AgentInfo,
+                {
+                    "name": "cursor",
+                    "hooks_installed": True,
+                    "hooks_command": "ggshield hooks install cursor",
+                },
+            ),
+            (
                 AIDiscoverySchema,
                 AIDiscovery,
                 {
@@ -498,6 +517,13 @@ class TestModel:
                         {
                             "name": "mcp-server",
                             "url": "https://mcp-server.com",
+                        },
+                    ],
+                    "agents": [
+                        {
+                            "name": "cursor",
+                            "hooks_installed": True,
+                            "hooks_command": "ggshield hooks install cursor",
                         },
                     ],
                 },


### PR DESCRIPTION
When sending an AI Discovery, we now want to also include whether the hooks are globally installed per agent (and with which command).