### PR TITLE
fix(client): return Detail on non-JSON 2xx for api_tokens and honeytoken-with-context

### DIFF
--- a/changelog.d/20260622_163617_benjamin.rigaud_harden_api_tokens_non_json.md
+++ b/changelog.d/20260622_163617_benjamin.rigaud_harden_api_tokens_non_json.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `api_tokens()` and `create_honeytoken_with_context()` now return a `Detail` instead of raising a raw `JSONDecodeError` when the server answers a `2xx` with a non-JSON body (e.g. an HTML page served when the instance URL is wrong). Like the other endpoints, they now gate JSON parsing on the response status and content type.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -425,7 +425,7 @@ class GGClient:
             result = Detail("The request timed out.")
             result.status_code = 504
         else:
-            if resp.ok:
+            if is_ok(resp):
                 result = APITokensResponse.from_dict(resp.json())
             else:
                 result = load_detail(resp)
@@ -741,7 +741,7 @@ class GGClient:
             result = Detail("The request timed out.")
             result.status_code = 504
         else:
-            if resp.ok:
+            if is_create_ok(resp):
                 result = HoneytokenWithContextResponse.from_dict(resp.json())
             else:
                 result = load_detail(resp)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1003,7 +1003,7 @@ def test_api_tokens(client: GGClient, token):
     mock_response = responses.get(
         url=client._url_from_endpoint(f"api_tokens/{token}", "v1"),
         content_type="application/json",
-        status=201,
+        status=200,
         json={
             "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
             "name": "myTokenName",
@@ -1048,6 +1048,28 @@ def test_api_tokens_error(
 
     assert mock_response.call_count == 1
     assert isinstance(result, Detail)
+
+
+@responses.activate
+def test_api_tokens_non_json_body(client: GGClient):
+    """
+    GIVEN an api_tokens endpoint answering 200 with a non-JSON body
+        (e.g. the dashboard SPA's HTML, served when the instance URL is wrong)
+    WHEN calling api_tokens
+    THEN it returns a Detail instead of raising a raw JSONDecodeError
+    """
+    mock_response = responses.get(
+        url=client._url_from_endpoint("api_tokens/self", "v1"),
+        content_type="text/html",
+        status=200,
+        body="<!doctype html><html><body>GitGuardian</body></html>",
+    )
+
+    result = client.api_tokens()
+
+    assert mock_response.call_count == 1
+    assert isinstance(result, Detail)
+    assert result.status_code == 200
 
 
 @responses.activate
@@ -1188,6 +1210,32 @@ def test_create_honeytoken_with_context_error(
 
     assert mock_response.call_count == 1
     assert isinstance(result, Detail)
+
+
+@responses.activate
+def test_create_honeytoken_with_context_non_json_body(client: GGClient):
+    """
+    GIVEN the honeytoken with-context endpoint answering 2xx with a non-JSON body
+    WHEN calling create_honeytoken_with_context
+    THEN it returns a Detail instead of raising a raw JSONDecodeError
+    """
+    mock_response = responses.post(
+        url=client._url_from_endpoint("honeytokens/with-context", "v1"),
+        content_type="text/html",
+        status=201,
+        body="<!doctype html><html></html>",
+    )
+
+    result = client.create_honeytoken_with_context(
+        name="honeytoken A",
+        description="honeytoken used in the repository AA",
+        type_="AWS",
+        filename="aws.yaml",
+    )
+
+    assert mock_response.call_count == 1
+    assert isinstance(result, Detail)
+    assert result.status_code == 201
 
 
 @responses.activate


### PR DESCRIPTION
## Summary

`api_tokens()` and `create_honeytoken_with_context()` called `resp.json()` behind a bare `resp.ok`, so a **2xx response with a non-JSON body** — e.g. the dashboard SPA's HTML, returned when the instance URL is wrong — crashed callers with a raw `requests.exceptions.JSONDecodeError` instead of returning a `Detail`.

This is the root cause behind the ggshield `api-status` crash fixed defensively in GitGuardian/ggshield#1312.

## Fix

Gate JSON parsing on both the response status **and** content type via the existing `is_ok()` / `is_create_ok()` helpers — exactly what every other endpoint already does. A non-JSON body now falls through to `load_detail()` and a `Detail` is returned.

- `api_tokens()` → `is_ok(resp)` (200 + JSON)
- `create_honeytoken_with_context()` → `is_create_ok(resp)` (201 + JSON), matching `create_honeytoken()`

The existing `test_api_tokens` success case mocked a `201`; corrected to the `200` the endpoint actually returns (required by `is_ok`).

## Test plan
- [x] New tests: a non-JSON `2xx` body returns a `Detail` (not a raised `JSONDecodeError`) for both `api_tokens()` and `create_honeytoken_with_context()`
- [x] Existing success/error tests for both endpoints still pass
- [x] Full suite: 125 passed; black clean
