### PR TITLE
Add AI_DISCOVER_SEND = "ai-discover:send" to the APIScopes enum

### DIFF
--- a/changelog.d/20260624_000000_gmendy_ai_discover_send_scope.md
+++ b/changelog.d/20260624_000000_gmendy_ai_discover_send_scope.md
@@ -1,0 +1,3 @@
+### Added
+
+- New `ai-discover:send` token scope.

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -786,6 +786,7 @@ class TokenScope(str, Enum):
     NHI_WRITE_VAULT = "nhi:write-vault"
     NHI_SEND_INVENTORY = "nhi:send-inventory"
     ENDPOINTS_SEND = "endpoints:send"
+    AI_DISCOVER_SEND = "ai-discover:send"
     CUSTOM_TAGS_READ = "custom_tags:read"
     CUSTOM_TAGS_WRITE = "custom_tags:write"
     SECRET_READ = "secrets:read"


### PR DESCRIPTION
`ai-discover:send` is a new GIM API scope that gates the MCP AI discovery endpoints (`/exposed/v1/nhi/ai/discovery`, `/exposed/v1/nhi/ai/mcp-activity`, `/exposed/v1/nhi/ai/mcp-activity/bulk`). It is available to all member types on business accounts.