### PR TITLE
feat(client): migrate MCP endpoints from nhi/ai/... to agent-activity/...

### DIFF
--- a/changelog.d/20260624_000000_gmendy_NHI-1744_migrate-mcp-routes.md
+++ b/changelog.d/20260624_000000_gmendy_NHI-1744_migrate-mcp-routes.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- Update MCP endpoint paths from `nhi/ai/...` to `agent-activity/...` following server-side route migration (NHI-1744).
+- Update MCP endpoint paths from `nhi/ai/...` to `agent-activity/...` following server-side route migration.

--- a/changelog.d/20260624_000000_gmendy_NHI-1744_migrate-mcp-routes.md
+++ b/changelog.d/20260624_000000_gmendy_NHI-1744_migrate-mcp-routes.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Update MCP endpoint paths from `nhi/ai/...` to `agent-activity/...` following server-side route migration (NHI-1744).

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -1207,7 +1207,7 @@ class GGClient:
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, AIDiscovery]:
         response = self.post(
-            endpoint="nhi/ai/discovery",
+            endpoint="agent-activity/discovery",
             data=ai_discovery.to_dict(),
             extra_headers=extra_headers,
         )
@@ -1227,7 +1227,7 @@ class GGClient:
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, MCPActivityResponse]:
         response = self.post(
-            endpoint="nhi/ai/mcp-activity",
+            endpoint="agent-activity/mcp-activity",
             data=activity.to_dict(),
             extra_headers=extra_headers,
         )
@@ -1247,7 +1247,7 @@ class GGClient:
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, MCPActivityBulkResponse]:
         response = self.post(
-            endpoint="nhi/ai/mcp-activity/bulk",
+            endpoint="agent-activity/mcp-activity/bulk",
             data={"activities": [a.to_dict() for a in activities]},
             extra_headers=extra_headers,
         )

--- a/tests/cassettes/test_log_mcp_activities_bulk_posts_to_correct_endpoint.yaml
+++ b/tests/cassettes/test_log_mcp_activities_bulk_posts_to_correct_endpoint.yaml
@@ -20,7 +20,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.30.0 (Linux;py3.11.15)
       method: POST
-      uri: https://api.gitguardian.com/v1/nhi/ai/mcp-activity/bulk
+      uri: https://api.gitguardian.com/v1/agent-activity/mcp-activity/bulk
     response:
       body:
         string: '{"ingested": 2, "duplicates": 0, "skipped": 0}'

--- a/tests/cassettes/test_log_mcp_activity.yaml
+++ b/tests/cassettes/test_log_mcp_activity.yaml
@@ -18,7 +18,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.29.0 (Linux;py3.11.15)
       method: POST
-      uri: https://api.gitguardian.com/v1/nhi/ai/mcp-activity
+      uri: https://api.gitguardian.com/v1/agent-activity/mcp-activity
     response:
       body:
         string: '{"allowed":true,"reason":""}'

--- a/tests/cassettes/test_send_ai_discovery.yaml
+++ b/tests/cassettes/test_send_ai_discovery.yaml
@@ -20,7 +20,7 @@ interactions:
         User-Agent:
           - pygitguardian/1.29.0 (Linux;py3.11.15)
       method: POST
-      uri: https://api.gitguardian.com/v1/nhi/ai/discovery
+      uri: https://api.gitguardian.com/v1/agent-activity/discovery
     response:
       body:
         string: '{"user":{"hostname":"toto-laptop","username":"toto","machine_id":"1234567890","user_email":"toto@gitguardian.com"},"servers":[{"name":"https://mcp-server-1.com","display_name":"","tools":[],"resources":[],"prompts":[],"configurations":[{"name":"mcp-configuration-1","agent":"cursor","scope":"user","transport":"http","project":null,"command":null,"args":[],"env":{},"url":"https://mcp-server-1.com","headers":{}}]}],"discovery_duration":0.5}'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1962,7 +1962,7 @@ def test_delete_invitation(client: GGClient):
 def test_send_ai_discovery(client: GGClient):
     """
     GIVEN a client
-    WHEN calling POST /nhi/ai/discovery endpoint
+    WHEN calling POST /agent-activity/discovery endpoint
     THEN an AI discovery is sent
     """
 
@@ -2006,7 +2006,7 @@ def test_send_ai_discovery(client: GGClient):
 def test_log_mcp_activity(client: GGClient):
     """
     GIVEN a client
-    WHEN calling POST /nhi/ai/mcp-activity endpoint
+    WHEN calling POST /agent-activity/mcp-activity endpoint
     THEN an MCP activity is logged
     """
 


### PR DESCRIPTION
## Summary

- Update the three MCP endpoint paths in \`pygitguardian/client.py\` following the server-side route migration (NHI-1744)
- Update VCR cassettes to match the new URLs
- Add changelog fragment

Old → new paths:
- `nhi/ai/discovery` → `agent-activity/discovery`
- `nhi/ai/mcp-activity` → `agent-activity/mcp-activity`
- `nhi/ai/mcp-activity/bulk` → `agent-activity/mcp-activity/bulk`

## Test plan
- [ ] Existing VCR-based tests pass with updated cassettes
- [ ] Changelog fragment present (`changelog.d/`)"