### PR TITLE
fix(client): accept the 200 returned by honeytokens/with-context

### DIFF
--- a/changelog.d/20260728_141956_clement.tourriere_fix_honeytoken_with_context_status.md
+++ b/changelog.d/20260728_141956_clement.tourriere_fix_honeytoken_with_context_status.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `create_honeytoken_with_context()` treated every successful response as an error: 1.33.0 started requiring a `201` status, but the `/v1/honeytokens/with-context` endpoint answers `200`. Successful responses were parsed as an error `Detail`, raising a `ValidationError`.

--- a/pygitguardian/client.py
+++ b/pygitguardian/client.py
@@ -741,7 +741,7 @@ class GGClient:
             result = Detail("The request timed out.")
             result.status_code = 504
         else:
-            if is_create_ok(resp):
+            if is_ok(resp):
                 result = HoneytokenWithContextResponse.from_dict(resp.json())
             else:
                 result = load_detail(resp)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1157,7 +1157,7 @@ def test_create_honeytoken_with_context(
     mock_response = responses.post(
         url=client._url_from_endpoint("honeytokens/with-context", "v1"),
         content_type="application/json",
-        status=201,
+        status=200,
         json={
             "content": "def return_aws_credentials():\n \
                             aws_access_key_id = XXXXXXXX\n \
@@ -1222,7 +1222,7 @@ def test_create_honeytoken_with_context_non_json_body(client: GGClient):
     mock_response = responses.post(
         url=client._url_from_endpoint("honeytokens/with-context", "v1"),
         content_type="text/html",
-        status=201,
+        status=200,
         body="<!doctype html><html></html>",
     )
 
@@ -1235,7 +1235,7 @@ def test_create_honeytoken_with_context_non_json_body(client: GGClient):
 
     assert mock_response.call_count == 1
     assert isinstance(result, Detail)
-    assert result.status_code == 201
+    assert result.status_code == 200
 
 
 @responses.activate


### PR DESCRIPTION
## What

`create_honeytoken_with_context()` treats every successful response as an error since 1.33.0: d1486fc tightened its success check from `resp.ok` to `is_create_ok()` (201 only), but the `/v1/honeytokens/with-context` endpoint answers **200** on success — unlike `/v1/honeytokens`, which answers 201 (see [the public OpenAPI spec](https://api.gitguardian.com/v1/openapi.json)). Successful creations were parsed as an error `Detail`, raising `ValidationError({'detail': ['Missing data for required field.']})`.

Caught by ggshield's VCR-based test suite when bumping to the 1.33.0 PyPI release (GitGuardian/ggshield#1365): its cassette replays a real 200 recorded from the API.

## Fix

Gate on `is_ok()` (200 + JSON) instead, keeping the non-JSON-body hardening from d1486fc, and align the test mocks with the status the endpoint actually returns.