### PR TITLE
feat(models): add subscription_email to AgentInfo

### DIFF
--- a/changelog.d/20260812_120000_achille.mascia_agent_info_subscription_email.md
+++ b/changelog.d/20260812_120000_achille.mascia_agent_info_subscription_email.md
@@ -1,0 +1,4 @@
+### Added
+
+- `AgentInfo.subscription_email`: the email of the assistant subscription an AI agent is signed into, so a personal
+  subscription can be told apart from a company one. Optional — agents that keep no account readable on disk send nothing.

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -1792,12 +1792,16 @@ class AgentInfo(FromDictMixin, ToDictMixin):
     # Whether the ggshield AI hooks are installed for this agent (globally).
     hooks_installed: bool
     hooks_command: Optional[str] = None
+    # Email of the assistant subscription this agent is signed into, when readable
+    # locally. Per-agent: one machine can mix a work seat and a personal one.
+    subscription_email: Optional[str] = None
 
 
 class AgentInfoSchema(BaseSchema):
     name = fields.Str(required=True)
     hooks_installed = fields.Bool(required=True)
     hooks_command = fields.Str(load_default=None, dump_default=None)
+    subscription_email = fields.Str(load_default=None, dump_default=None)
 
     @post_load
     def make_agent_info(self, data: Dict[str, Any], **kwargs: Any):


### PR DESCRIPTION
The email of the assistant subscription an AI agent is signed into, so a personal subscription can be told apart from a company one.

Per-agent rather than on `UserInfo`: one machine can mix a work seat and a personal one. Optional both ways — agents that keep no account readable on disk send nothing.

Consumed by [ggshield#1408](https://github.com/GitGuardian/ggshield/pull/1408).