### PR TITLE
fix(models): don't raise ValidationError on unrecognized enum values from the API

### DIFF
--- a/changelog.d/20260817_151236_nathan.riviere_scan_status_forward_compat.md
+++ b/changelog.d/20260817_151236_nathan.riviere_scan_status_forward_compat.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Source.last_scan.status`, `Source.health`, `Source.source_criticality`, `Member.access_level`, `Invitation.access_level`, `TeamMember`/`TeamInvitation` permission fields, and related models no longer raise `marshmallow.exceptions.ValidationError` when the API returns a value added after this SDK version (e.g. the new `skipped`/`launched`/`running_failed`/`running_cancelled` scan statuses). These fields now accept any string, falling back to the raw value for statuses/levels the SDK doesn't have a named constant for yet, instead of failing to deserialize the whole object.

--- a/pygitguardian/models.py
+++ b/pygitguardian/models.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Type, cast
+from typing import Any, Dict, List, Literal, Optional, Type, Union, cast
 from uuid import UUID
 
 import marshmallow_dataclass
@@ -29,6 +29,7 @@ from .models_utils import (
     BaseSchema,
     FromDictMixin,
     FromDictWithBase,
+    LenientEnum,
     PaginationParameter,
     PaginationParameterSchema,
     SearchParameter,
@@ -972,15 +973,23 @@ class SecretIncidentsBreakdown(Base, FromDictMixin):
     closed_secret_incidents: SecretIncidentStats
 
 
-ScanStatus = Literal[
-    "pending",
-    "running",
-    "canceled",
-    "failed",
-    "too_large",
-    "timeout",
-    "pending_timeout",
-    "finished",
+# `str` fallback so a status the API adds later doesn't break deserialization.
+ScanStatus = Union[
+    Literal[
+        "pending",
+        "running",
+        "canceled",
+        "failed",
+        "too_large",
+        "timeout",
+        "pending_timeout",
+        "finished",
+        "launched",
+        "skipped",
+        "running_failed",
+        "running_cancelled",
+    ],
+    str,
 ]
 
 
@@ -994,8 +1003,9 @@ class Scan(Base, FromDictMixin):
     duration: str
 
 
-SourceHealth = Literal["safe", "unknown", "at_risk"]
-SourceCriticality = Literal["critical", "high", "medium", "low", "unknown"]
+# `str` fallback, same reasoning as ScanStatus above.
+SourceHealth = Union[Literal["safe", "unknown", "at_risk"], str]
+SourceCriticality = Union[Literal["critical", "high", "medium", "low", "unknown"], str]
 
 
 @dataclass
@@ -1163,7 +1173,7 @@ class Member(FromDictWithBase):
     """
 
     id: int
-    access_level: AccessLevel
+    access_level: Union[AccessLevel, str]
     email: str
     name: str
     created_at: datetime
@@ -1178,7 +1188,7 @@ class MemberSchema(BaseSchema):
     """
 
     id = fields.Int(required=True)
-    access_level = fields.Enum(AccessLevel, by_value=True, required=True)
+    access_level = LenientEnum(AccessLevel, required=True)
     email = fields.Str(required=True)
     name = fields.Str(required=True)
     created_at = fields.AwareDateTime(required=True)
@@ -1350,8 +1360,8 @@ class TeamInvitation(FromDictWithBase):
     id: int
     invitation_id: int
     team_id: int
-    team_permission: TeamPermission
-    incident_permission: IncidentPermission
+    team_permission: Union[TeamPermission, str]
+    incident_permission: Union[IncidentPermission, str]
 
 
 class TeamInvitationSchema(BaseSchema):
@@ -1360,8 +1370,8 @@ class TeamInvitationSchema(BaseSchema):
     id = fields.Int(required=True)
     invitation_id = fields.Int(required=True)
     team_id = fields.Int(required=True)
-    team_permission = fields.Enum(TeamPermission, by_value=True, required=True)
-    incident_permission = fields.Enum(IncidentPermission, by_value=True, required=True)
+    team_permission = LenientEnum(TeamPermission, required=True)
+    incident_permission = LenientEnum(IncidentPermission, required=True)
 
     @post_load
     def make_team_invitation(
@@ -1379,7 +1389,7 @@ TeamInvitation.SCHEMA = TeamInvitationSchema()
 class CreateTeamInvitation(FromDictWithBase):
     invitation_id: int
     is_team_leader: bool
-    incident_permission: IncidentPermission
+    incident_permission: Union[IncidentPermission, str]
 
 
 class CreateTeamInvitationSchema(BaseSchema):
@@ -1387,7 +1397,7 @@ class CreateTeamInvitationSchema(BaseSchema):
 
     invitation_id = fields.Int(required=True)
     is_team_leader = fields.Bool(required=True)
-    incident_permission = fields.Enum(IncidentPermission, by_value=True, required=True)
+    incident_permission = LenientEnum(IncidentPermission, required=True)
 
     @post_load
     def make_team_invitation(self, data: Dict[str, Any], **kwargs: Any):
@@ -1434,8 +1444,8 @@ class TeamMember(FromDictWithBase):
     team_id: int
     member_id: int
     is_team_leader: bool
-    team_permission: TeamPermission
-    incident_permission: IncidentPermission
+    team_permission: Union[TeamPermission, str]
+    incident_permission: Union[IncidentPermission, str]
 
 
 class TeamMemberSchema(BaseSchema):
@@ -1443,8 +1453,8 @@ class TeamMemberSchema(BaseSchema):
     team_id = fields.Int(required=True)
     member_id = fields.Int(required=True)
     is_team_leader = fields.Bool(required=True)
-    team_permission = fields.Enum(TeamPermission, by_value=True, required=True)
-    incident_permission = fields.Enum(IncidentPermission, by_value=True, required=True)
+    team_permission = LenientEnum(TeamPermission, required=True)
+    incident_permission = LenientEnum(IncidentPermission, required=True)
 
     @post_load
     def make_team_member(self, data: Dict[str, Any], **kwargs: Any):
@@ -1472,7 +1482,7 @@ CreateTeamMemberParameters.SCHEMA = CreateTeamMemberParameterSchema()
 class CreateTeamMember(FromDictWithBase):
     member_id: int
     is_team_leader: bool
-    incident_permission: IncidentPermission
+    incident_permission: Union[IncidentPermission, str]
 
 
 class CreateTeamMemberSchema(BaseSchema):
@@ -1480,7 +1490,7 @@ class CreateTeamMemberSchema(BaseSchema):
 
     member_id = fields.Int(required=True)
     is_team_leader = fields.Bool(required=True)
-    incident_permission = fields.Enum(IncidentPermission, by_value=True, required=True)
+    incident_permission = LenientEnum(IncidentPermission, required=True)
 
     @post_load
     def make_create_team_member(self, data: Dict[str, Any], **kwargs: Any):
@@ -1545,14 +1555,14 @@ class InvitationParameters(
 class Invitation(FromDictWithBase):
     id: int
     email: str
-    access_level: AccessLevel
+    access_level: Union[AccessLevel, str]
     date: datetime
 
 
 class InvitationSchema(BaseSchema):
     id = fields.Int(required=True)
     email = fields.Str(required=True)
-    access_level = fields.Enum(AccessLevel, by_value=True, required=True)
+    access_level = LenientEnum(AccessLevel, required=True)
     date = fields.DateTime(required=True)
 
     @post_load
@@ -1580,12 +1590,12 @@ CreateInvitationParameters.SCHEMA = CreateInvitationParameterSchema()
 @dataclass
 class CreateInvitation(FromDictMixin, ToDictMixin):
     email: str
-    access_level: AccessLevel
+    access_level: Union[AccessLevel, str]
 
 
 class CreateInvitationSchema(BaseSchema):
     email = fields.Str(required=True)
-    access_level = fields.Enum(AccessLevel, by_value=True, required=True)
+    access_level = LenientEnum(AccessLevel, required=True)
 
     @post_load
     def make_create_invitation(self, data: Dict[str, Any], **kwargs: Any):

--- a/pygitguardian/models_utils.py
+++ b/pygitguardian/models_utils.py
@@ -2,6 +2,7 @@
 # Disable this check because of multiple non-dangerous violations (SCHEMA variables,
 # BaseSchema.Meta class)
 from dataclasses import dataclass
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,7 +17,7 @@ from typing import (
 )
 
 import marshmallow_dataclass
-from marshmallow import EXCLUDE, Schema
+from marshmallow import EXCLUDE, Schema, fields
 from typing_extensions import Self
 
 
@@ -57,6 +58,30 @@ class FromDictMixin:
 class BaseSchema(Schema):
     class Meta:
         unknown = EXCLUDE
+
+
+class LenientEnum(fields.Field):
+    """Like `fields.Enum(enum_class, by_value=True)`, but returns the raw
+    value instead of raising when it doesn't match a known member."""
+
+    def __init__(self, enum_class: Type[Enum], **kwargs: Any) -> None:
+        self.enum_class = enum_class
+        super().__init__(**kwargs)
+
+    def _serialize(
+        self, value: Any, attr: Optional[str], obj: Any, **kwargs: Any
+    ) -> Any:
+        if value is None:
+            return None
+        return value.value if isinstance(value, Enum) else value
+
+    def _deserialize(
+        self, value: Any, attr: Optional[str], data: Any, **kwargs: Any
+    ) -> Any:
+        try:
+            return self.enum_class(value)
+        except ValueError:
+            return value
 
 
 class Base(ToDictMixin):


### PR DESCRIPTION
ScanStatus, SourceHealth, SourceCriticality, AccessLevel, TeamPermission, and
IncidentPermission were closed Literal/Enum types, so any new value GIM added
to one of these fields broke deserialization of the whole object. This is
what happened when the `skipped` scan status shipped — `list_sources()` now
raises ValidationError for any account with a skipped source.

These fields now fall back to the raw string on unrecognized values instead
of raising, while still matching known values to their existing Literal/Enum.